### PR TITLE
Support for SRVs

### DIFF
--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -44,6 +44,7 @@ DescriptorSets:
 # RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil | FileCheck %s %}
 # RUN: %if Vulkan %{ dxc -T cs_6_0 -spirv -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.spv %t/source.hlsl %}
 # RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv | FileCheck %s %}
+# XFAIL: Vulkan
 
 # RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -8,8 +8,8 @@ struct S2 {
   int4 i;
 };
 
-RWStructuredBuffer<S1> In : register(u0);
-RWStructuredBuffer<S2> Out : register(u1);
+StructuredBuffer<S1> In : register(t0);
+RWStructuredBuffer<S2> Out : register(u0);
 
 [numthreads(1,1,1)]
 void main(uint GI : SV_GroupIndex) {
@@ -21,7 +21,7 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Access: ReadOnly
       Format: Hex32
       RawSize: 32
       Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003,
@@ -34,7 +34,7 @@ DescriptorSets:
       RawSize: 32
       ZeroInitSize: 32
       DirectXBinding:
-        Register: 1
+        Register: 0
         Space: 0
 ...
 #--- end
@@ -49,6 +49,19 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
+# CHECK: Access: ReadOnly
+# CHECK: Data: [
+# CHECK: 0x0,
+# CHECK: 0x1,
+# CHECK: 0x2,
+# CHECK: 0x3,
+# CHECK: 0x0,
+# CHECK: 0x3F800000,
+# CHECK: 0x40000000,
+# CHECK: 0x40400000
+# CHECK: ]
+
+# CHECK: Access: ReadWrite
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x3F800000,


### PR DESCRIPTION
This is mostly cargo-culting the logic from UAVs and adjusting for the simpler read-only case of SRVs.

Note that I don't have a setup locally for Vulkan right now, so I've just XFAIL'd the test in Vulkan configs for now.