### PR TITLE
Add StructuredBuffer SRV Test

### DIFF
--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -1,0 +1,59 @@
+#--- source.hlsl
+struct S1 {
+  int4 i;
+};
+
+StructuredBuffer<S1> In : register(t0);
+RWStructuredBuffer<S1> Out : register(u0);
+
+[numthreads(1,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out[GI].i = In[GI].i * 2.0;
+}
+//--- pipeline.yaml
+---
+DispatchSize: [1, 1, 1]
+DescriptorSets:
+  - Resources:
+    - Access: ReadOnly
+      Format: Hex32
+      RawSize: 32
+      Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Access: ReadWrite
+      Format: Hex32
+      RawSize: 16
+      ZeroInitSize: 16
+      DirectXBinding:
+        Register: 0
+        Space: 0
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %if DirectX %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
+# RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil | FileCheck %s %}
+# RUN: %if Vulkan %{ dxc -T cs_6_0 -spirv -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.spv %t/source.hlsl %}
+# RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv | FileCheck %s %}
+
+# RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
+# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
+# RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
+
+# CHECK: Access: ReadOnly
+# CHECK: Data: [
+# CHECK: 0x0,
+# CHECK: 0x1,
+# CHECK: 0x2,
+# CHECK: 0x3
+# CHECK: ]
+
+# CHECK: Access: ReadWrite
+# CHECK: Data: [
+# CHECK: 0x0,
+# CHECK: 0x2,
+# CHECK: 0x4,
+# CHECK: 0x6
+# CHECK: ]

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -17,7 +17,7 @@ DescriptorSets:
   - Resources:
     - Access: ReadOnly
       Format: Hex32
-      RawSize: 32
+      RawSize: 16
       Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
       DirectXBinding:
         Register: 0

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -44,7 +44,7 @@ DescriptorSets:
 # RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil | FileCheck %s %}
 # RUN: %if Vulkan %{ dxc -T cs_6_0 -spirv -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.spv %t/source.hlsl %}
 # RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv | FileCheck %s %}
-# XFAIL: Vulkan
+# XFAIL: DXC-Vulkan
 
 # RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -48,14 +48,18 @@ if config.offloadtest_test_warp:
 else:
   tools.append(ToolSubst("%offloader", FindTool("offloader")))
 
+HLSLCompiler = ''
 if config.offloadtest_test_clang:
   if os.path.exists(config.offloadtest_dxc_dir):
     tools.append(ToolSubst("dxc", FindTool("clang-dxc"), extra_args=["--dxv-path=%s" % config.offloadtest_dxc_dir]))
   else:
     tools.append(ToolSubst("dxc", FindTool("clang-dxc")))
-  config.available_features.add("Clang")
+  HLSLCompiler = 'Clang'
 else:
   tools.append(ToolSubst("dxc", config.offloadtest_dxc))
+  HLSLCompiler = 'DXC'
+
+config.available_features.add(HLSLCompiler)
 
 llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)
 
@@ -66,12 +70,15 @@ devices = yaml.safe_load(query_string)
 for device in devices['Devices']:
   if device['API'] == "DirectX" and config.offloadtest_enable_d3d12:
     config.available_features.add("DirectX")
+    config.available_features.add(HLSLCompiler + "-DirectX")
     if "Intel" in device['Description']:
       config.available_features.add("DirectX-Intel")
   if device['API'] == "Metal" and config.offloadtest_enable_metal:
     config.available_features.add("Metal")
+    config.available_features.add(HLSLCompiler + "-Metal")
   if device['API'] == "Vulkan" and config.offloadtest_enable_vulkan:
     config.available_features.add("Vulkan")
+    config.available_features.add(HLSLCompiler + "-Vulkan")
     if "NVIDIA" in device['Description']:
       config.available_features.add("Vulkan-NV")
 


### PR DESCRIPTION
Vulkan doesn't have the same division between SRV and UAV that DirectX does, so this refactors the buffer handling code to merge SRVs and UAVs. We will need different handling for other types of buffers in the future (i.e. CBVs which map to uniform buffers), but for now this gets pairity between DX and VK.

The SRV test for structured buffers that @bogner added in his last PR miscompiles to DXC SPIR-V, so this PR adds a new test to handle more basic StructuredBuffer SRV use.