### PR TITLE
Rework Access to Kind

### DIFF
--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -29,7 +29,7 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
 
 void MappingTraits<offloadtest::Resource>::mapping(IO &I,
                                                    offloadtest::Resource &R) {
-  I.mapRequired("Access", R.Access);
+  I.mapRequired("Kind", R.Kind);
   I.mapRequired("Format", R.Format);
   I.mapOptional("Channels", R.Channels, 1);
   I.mapOptional("RawSize", R.RawSize, 0);

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -20,14 +20,14 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       Data: [ 2, 4, 6, 8]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       ZeroInitSize: 16
@@ -35,7 +35,7 @@ DescriptorSets:
         Register: 1
         Space: 4
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       ZeroInitSize: 16

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -57,7 +57,7 @@ const static int Dimension = 4096;
 DispatchSize: [16384, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       ZeroInitSize: 268435456 # 1024 * 1024 * 4 channels / pixel * 4 bytes / channel

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -15,14 +15,14 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadOnly
+    - Kind: StructuredBuffer
       Format: Hex32
       RawSize: 16
       Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Hex32
       RawSize: 16
       ZeroInitSize: 16
@@ -42,7 +42,7 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Access: ReadOnly
+# CHECK: Kind: StructuredBuffer
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x1,
@@ -50,7 +50,7 @@ DescriptorSets:
 # CHECK: 0x3
 # CHECK: ]
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x2,

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -20,7 +20,7 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Int32
       RawSize: 24
       Data: [ 0, 1, 2, 0, 4, 0, 1, 2, 3, 0, 4, 0]

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -21,7 +21,7 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadOnly
+    - Kind: StructuredBuffer
       Format: Hex32
       RawSize: 32
       Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003,
@@ -29,7 +29,7 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Hex32
       RawSize: 32
       ZeroInitSize: 32
@@ -50,7 +50,7 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Access: ReadOnly
+# CHECK: Kind: StructuredBuffer
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x1,
@@ -62,7 +62,7 @@ DescriptorSets:
 # CHECK: 0x40400000
 # CHECK: ]
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x3F800000,

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -12,13 +12,13 @@ void main(uint3 TID : SV_GroupThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Data: [ 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8 ]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Data: [ 9.9, 10.1, 11.1, 12.2, 13.3, 14.4, 15.5, 16.6]
       DirectXBinding:
@@ -37,9 +37,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Float32
 # CHECK: Data: [ 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8 ]
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Float32
 # CHECK: Data: [ 5.4, 6.5, 7.6, 8.7, 9.8, 10.9, 12, 13.1 ]

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -13,13 +13,13 @@ void main(uint3 TID : SV_GroupThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Int32
       Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Int32
       Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
       DirectXBinding:
@@ -38,9 +38,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -24,19 +24,19 @@ void main(uint3 TID : SV_GroupThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Int32
       Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Int32
       Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
       DirectXBinding:
         Register: 1
         Space: 0
-    - Access: Constant
+    - Kind: ConstantBuffer
       Format: Int32
       Data: [ 4, 0, 0, 0]
       DirectXBinding:
@@ -55,9 +55,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWBuffer
 # CHECK: Format: Int32
 # CHECK: Data: [ 4, 8, 12, 16, 20, 24, 28, 32 ]

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -16,21 +16,21 @@ void main(uint3 TID : SV_GroupThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Int32
       RawSize: 4
       Data: [ 1, -1, 2147483647, 0, -2147483648]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Int32
       RawSize: 4
       Data: [ 0, 0, 0, 0, 0]
       DirectXBinding:
         Register: 1
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Int32
       RawSize: 4
       Data: [ -1, -1, -1, -1, -1]
@@ -52,9 +52,9 @@ DescriptorSets:
 
 # Divide by-zero behavior seems to be erradic enough to call it undefined...
 
-# CHECK: Access: ReadWrite
-# CHECK: Access: ReadWrite
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
+# CHECK: Kind: RWStructuredBuffer
+# CHECK: Kind: RWStructuredBuffer
 # CHECK-NEXT: Format: Int32
 # CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ -1, 1, -2147483647, 0

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -18,14 +18,14 @@ void main(uint GI : SV_GroupIndex) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       Data: [ 2, 4, 6, 8]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Float32
       Channels: 4
       ZeroInitSize: 16

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -17,28 +17,28 @@ void main(uint3 TID : SV_GroupThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Float32
       RawSize: 4
       Data: [ nan, nan, nan, nan ]
       DirectXBinding:
         Register: 0
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Float32
       RawSize: 4
       Data: [ inf, inf, inf, inf ]
       DirectXBinding:
         Register: 1
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Float32
       RawSize: 4
       Data: [ -inf, -inf, -inf, -inf ]
       DirectXBinding:
         Register: 2
         Space: 0
-    - Access: ReadWrite
+    - Kind: RWStructuredBuffer
       Format: Float32
       RawSize: 4
       Data: [ inf, -inf, nan, 0 ]
@@ -79,21 +79,21 @@ DescriptorSets:
 
 # XFAIL: DirectX-WARP
 
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK-NEXT: Format: Float32
 # CHECK-NEXT: RawSize: 4
 # METAL-NEXT: Data: [ 0, 0, 0, 0 ]
 # DX-NEXT: Data:
 # VULKAN-NEXT: Data:
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK-NEXT: Format: Float32
 # CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ inf, inf, inf, inf ]
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK-NEXT: Format: Float32
 # CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ 0, 0, 0, 0 ]
-# CHECK: Access: ReadWrite
+# CHECK: Kind: RWStructuredBuffer
 # CHECK-NEXT: Format: Float32
 # CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ inf, inf, inf, inf ]

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -20,7 +20,7 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 DispatchSize: [1, 1, 1]
 DescriptorSets:
   - Resources:
-    - Access: ReadWrite
+    - Kind: RWBuffer
       Format: Int32
       Data: [ 0, 0, 1, 2]
       DirectXBinding:


### PR DESCRIPTION
The mappings between HLSL resource types across APIs is a bit wonky and complicated. It is probably just easier if the test cases define the HLSL resource kind in the YAML and the offloader just maps it to "the right thing"

I have another bigger change I want to make here to separate defining resources from defining their bindings. I'll do that next.