### PR TITLE
Refactor defining buffers to use named buffers

### DIFF
--- a/include/Image/Image.h
+++ b/include/Image/Image.h
@@ -85,12 +85,12 @@ public:
     assert(Data.size() == size() && "Data size does not match properties");
   }
 
-  ImageRef(const Resource &R)
-      : ImageRef(R.OutputProps.Height, R.OutputProps.Width,
-                 R.getSingleElementSize(), R.Channels,
-                 R.Format == DataFormat::Float32 ||
-                     R.Format == DataFormat::Float64,
-                 llvm::StringRef(R.Data.get(), R.Size)) {}
+  ImageRef(const Buffer &B)
+      : ImageRef(
+            B.OutputProps.Height, B.OutputProps.Width,
+            B.getSingleElementSize(), B.Channels,
+            B.Format == DataFormat::Float32 || B.Format == DataFormat::Float64,
+            llvm::StringRef(B.Data.get(), B.size())) {}
 
   uint32_t getHeight() const { return Height; }
   uint32_t getWidth() const { return Width; }

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -59,13 +59,12 @@ struct Buffer {
   std::string Name;
   DataFormat Format;
   int Channels;
+  int Stride;
   std::unique_ptr<char[]> Data;
   size_t Size;
   OutputProperties OutputProps;
 
-  uint32_t size() const {
-    return Size;
-  }
+  uint32_t size() const { return Size; }
 
   uint32_t getSingleElementSize() const {
     switch (Format) {
@@ -90,6 +89,8 @@ struct Buffer {
   }
 
   uint32_t getElementSize() const {
+    if (Stride > 0)
+      return Stride;
     return getSingleElementSize() * Channels;
   }
 };
@@ -101,41 +102,34 @@ struct Resource {
   Buffer *BufferPtr = nullptr;
 
   bool isRaw() const {
-      switch (Kind) {
-      case ResourceKind::Buffer:
-      case ResourceKind::RWBuffer:
+    switch (Kind) {
+    case ResourceKind::Buffer:
+    case ResourceKind::RWBuffer:
       return false;
-      case ResourceKind::StructuredBuffer:
-      case ResourceKind::RWStructuredBuffer:
-      case ResourceKind::ConstantBuffer:
+    case ResourceKind::StructuredBuffer:
+    case ResourceKind::RWStructuredBuffer:
+    case ResourceKind::ConstantBuffer:
       return true;
-      }
-      llvm_unreachable("All cases handled");
+    }
+    llvm_unreachable("All cases handled");
   }
 
-  uint32_t getElementSize() const {
-    if (isRaw())
-      return BufferPtr->Size;
-    return BufferPtr->getElementSize();
-  }
+  uint32_t getElementSize() const { return BufferPtr->getElementSize(); }
 
-  uint32_t size() const {
-    return BufferPtr->size();
-  }
+  uint32_t size() const { return BufferPtr->size(); }
 
   bool isReadWrite() const {
     switch (Kind) {
     case ResourceKind::Buffer:
     case ResourceKind::StructuredBuffer:
     case ResourceKind::ConstantBuffer:
-    return false;
+      return false;
     case ResourceKind::RWBuffer:
     case ResourceKind::RWStructuredBuffer:
-    return true;
+      return true;
     }
     llvm_unreachable("All cases handled");
-}
-
+  }
 };
 
 struct DescriptorSet {

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -50,52 +50,21 @@ struct DirectXBinding {
 };
 
 struct OutputProperties {
-  std::string Name;
   int Height;
   int Width;
   int Depth;
 };
 
-struct Resource {
+struct Buffer {
+  std::string Name;
   DataFormat Format;
   int Channels;
-  int RawSize;
-  ResourceKind Kind;
-  size_t Size;
   std::unique_ptr<char[]> Data;
-  DirectXBinding DXBinding;
+  size_t Size;
   OutputProperties OutputProps;
 
-  bool isRaw() const {
-      switch (Kind) {
-      case ResourceKind::Buffer:
-      case ResourceKind::RWBuffer:
-      return false;
-      case ResourceKind::StructuredBuffer:
-      case ResourceKind::RWStructuredBuffer:
-      case ResourceKind::ConstantBuffer:
-      return true;
-      }
-      llvm_unreachable("All cases handled");
-  }
-
-  bool isReadWrite() const {
-    switch (Kind) {
-    case ResourceKind::Buffer:
-    case ResourceKind::StructuredBuffer:
-    case ResourceKind::ConstantBuffer:
-    return false;
-    case ResourceKind::RWBuffer:
-    case ResourceKind::RWStructuredBuffer:
-    return true;
-    }
-    llvm_unreachable("All cases handled");
-}
-
-  uint32_t getElementSize() const {
-    if (isRaw())
-      return RawSize;
-    return getSingleElementSize() * Channels;
+  uint32_t size() const {
+    return Size;
   }
 
   uint32_t getSingleElementSize() const {
@@ -119,6 +88,54 @@ struct Resource {
     }
     llvm_unreachable("All cases covered.");
   }
+
+  uint32_t getElementSize() const {
+    return getSingleElementSize() * Channels;
+  }
+};
+
+struct Resource {
+  ResourceKind Kind;
+  std::string Name;
+  DirectXBinding DXBinding;
+  Buffer *BufferPtr = nullptr;
+
+  bool isRaw() const {
+      switch (Kind) {
+      case ResourceKind::Buffer:
+      case ResourceKind::RWBuffer:
+      return false;
+      case ResourceKind::StructuredBuffer:
+      case ResourceKind::RWStructuredBuffer:
+      case ResourceKind::ConstantBuffer:
+      return true;
+      }
+      llvm_unreachable("All cases handled");
+  }
+
+  uint32_t getElementSize() const {
+    if (isRaw())
+      return BufferPtr->Size;
+    return BufferPtr->getElementSize();
+  }
+
+  uint32_t size() const {
+    return BufferPtr->size();
+  }
+
+  bool isReadWrite() const {
+    switch (Kind) {
+    case ResourceKind::Buffer:
+    case ResourceKind::StructuredBuffer:
+    case ResourceKind::ConstantBuffer:
+    return false;
+    case ResourceKind::RWBuffer:
+    case ResourceKind::RWStructuredBuffer:
+    return true;
+    }
+    llvm_unreachable("All cases handled");
+}
+
 };
 
 struct DescriptorSet {
@@ -127,6 +144,7 @@ struct DescriptorSet {
 
 struct Pipeline {
   int DispatchSize[3];
+  llvm::SmallVector<Buffer> Buffers;
   llvm::SmallVector<DescriptorSet> Sets;
 
   uint32_t getDescriptorCount() const {
@@ -140,6 +158,7 @@ struct Pipeline {
 
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DescriptorSet)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Resource)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Buffer)
 
 namespace llvm {
 namespace yaml {
@@ -150,6 +169,10 @@ template <> struct MappingTraits<offloadtest::Pipeline> {
 
 template <> struct MappingTraits<offloadtest::DescriptorSet> {
   static void mapping(IO &I, offloadtest::DescriptorSet &D);
+};
+
+template <> struct MappingTraits<offloadtest::Buffer> {
+  static void mapping(IO &I, offloadtest::Buffer &R);
 };
 
 template <> struct MappingTraits<offloadtest::Resource> {

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -465,7 +465,7 @@ public:
     const D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {
         EltFormat,
         D3D12_UAV_DIMENSION_BUFFER,
-        {D3D12_BUFFER_UAV{0, NumElts, static_cast<uint32_t>(R.size()), 0,
+        {D3D12_BUFFER_UAV{0, NumElts, R.isRaw() ? R.getElementSize() : 0, 0,
                           D3D12_BUFFER_UAV_FLAG_NONE}}};
 
     llvm::outs() << "UAV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -317,7 +317,7 @@ public:
                            const uint32_t HeapIdx) {
     auto ExHostBuf = createBuffer(
         IS, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, R.Size, R.Data.get());
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, R.size(), R.BufferPtr->Data.get());
     if (!ExHostBuf)
       return ExHostBuf.takeError();
 
@@ -326,16 +326,16 @@ public:
         (R.isRaw() ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
                    : VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) |
             VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, R.Size);
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, R.size());
     if (!ExDeviceBuf)
       return ExDeviceBuf.takeError();
 
     VkBufferCopy Copy = {};
-    Copy.size = R.Size;
+    Copy.size = R.size();
     vkCmdCopyBuffer(IS.CmdBuffer, ExHostBuf->Buffer, ExDeviceBuf->Buffer, 1,
                     &Copy);
 
-    IS.Buffers.push_back(ResourceRef{*ExHostBuf, *ExDeviceBuf, R.Size});
+    IS.Buffers.push_back(ResourceRef{*ExHostBuf, *ExDeviceBuf, R.size()});
 
     return llvm::Error::success();
   }
@@ -344,7 +344,7 @@ public:
                         const uint32_t HeapIdx) {
     auto ExHostBuf = createBuffer(
         IS, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, R.Size, R.Data.get());
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, R.size(), R.BufferPtr->Data.get());
     if (!ExHostBuf)
       return ExHostBuf.takeError();
 
@@ -352,16 +352,16 @@ public:
         IS,
         VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
             VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, R.Size);
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, R.size());
     if (!ExDeviceBuf)
       return ExDeviceBuf.takeError();
 
     VkBufferCopy Copy = {};
-    Copy.size = R.Size;
+    Copy.size = R.size();
     vkCmdCopyBuffer(IS.CmdBuffer, ExHostBuf->Buffer, ExDeviceBuf->Buffer, 1,
                     &Copy);
 
-    IS.Buffers.push_back(ResourceRef{*ExHostBuf, *ExDeviceBuf, R.Size});
+    IS.Buffers.push_back(ResourceRef{*ExHostBuf, *ExDeviceBuf, R.size()});
 
     return llvm::Error::success();
   }
@@ -527,7 +527,8 @@ public:
         VkBufferViewCreateInfo ViewCreateInfo = {};
         bool IsRawOrUniform = R.isRaw();
         VkFormat Format = IsRawOrUniform ? VK_FORMAT_UNDEFINED
-                                         : getVKFormat(R.Format, R.Channels);
+                                         : getVKFormat(R.BufferPtr->Format,
+                                                       R.BufferPtr->Channels);
         ViewCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
         ViewCreateInfo.buffer = IS.Buffers[BufIdx].Device.Buffer;
         ViewCreateInfo.format = Format;
@@ -670,7 +671,7 @@ public:
         Range.offset = 0;
         Range.size = VK_WHOLE_SIZE;
         vkInvalidateMappedMemoryRanges(IS.Device, 1, &Range);
-        memcpy(R.Data.get(), Mapped, R.Size);
+        memcpy(R.BufferPtr->Data.get(), Mapped, R.size());
         vkUnmapMemory(IS.Device, IS.Buffers[UAVIdx].Host.Memory);
         UAVIdx++;
       }

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -46,6 +46,9 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
   I.mapRequired("Name", B.Name);
   I.mapRequired("Format", B.Format);
   I.mapOptional("Channels", B.Channels, 1);
+  I.mapOptional("Stride", B.Stride, 0);
+  if (!I.outputting() && B.Stride != 0 && B.Channels != 1)
+    I.setError("Cannot set a structure stride and more than one channel.");
   switch (B.Format) {
 #define DATA_CASE(Enum, Type)                                                  \
   case DataFormat::Enum: {                                                     \

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -64,5 +64,7 @@ DescriptorSets:
 # RUN: %if Metal %{ %offloader %t/DescriptorSets.yaml %t.metallib | FileCheck %s %}
 
 # CHECK: Data:
+# CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 4, 16, 36, 64 ]
+# CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 8, 64, 216, 512 ]

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -18,27 +18,34 @@ void main(uint GI : SV_GroupIndex) {
 //--- DescriptorSets.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Channels: 4
+    Data: [ 2, 4, 6, 8]
+  - Name: Out1
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
+  - Name: Out2
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      Data: [ 2, 4, 6, 8]
+    - Name: In
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      ZeroInitSize: 16
+    - Name: Out1
+      Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 4
   - Resources:
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      ZeroInitSize: 16
+    - Name: Out2
+      Kind: RWBuffer
       DirectXBinding:
         Register: 2
         Space: 4

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -55,20 +55,22 @@ const static int Dimension = 4096;
 //--- pipeline.yaml
 ---
 DispatchSize: [16384, 1, 1]
+Buffers:
+  - Name: Tex
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 268435456 # 1024 * 1024 * 4 channels / pixel * 4 bytes / channel
+    OutputProps:
+      Height: 4096
+      Width: 4096
+      Depth: 16
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      ZeroInitSize: 268435456 # 1024 * 1024 * 4 channels / pixel * 4 bytes / channel
+    - Name: Tex
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-      OutputProps:
-        Name: Output
-        Height: 4096
-        Width: 4096
-        Depth: 16
 ...
 #--- rules.yaml
 ---
@@ -95,10 +97,10 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %if DirectX %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
-# RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil -r Output -o %t/output.png %}
+# RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil -r Tex -o %t/output.png %}
 # RUN: %if Vulkan %{ dxc -T cs_6_0 -spirv -Fo %t.spv %t/source.hlsl %}
-# RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv -r Output -o %t/output.png %}
+# RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv -r Tex -o %t/output.png %}
 # RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
-# RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib -r Output -o %t/output.png %}
+# RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib -r Tex -o %t/output.png %}
 # RUN: imgdiff %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png -rules %t/rules.yaml

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -13,19 +13,22 @@ void main(uint GI : SV_GroupIndex) {
 //--- pipeline.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Hex32
+    Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
+  - Name: Out
+    Format: Hex32
+    ZeroInitSize: 16
 DescriptorSets:
   - Resources:
-    - Kind: StructuredBuffer
-      Format: Hex32
-      RawSize: 16
-      Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
+    - Name: In
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Hex32
-      RawSize: 16
-      ZeroInitSize: 16
+    - Name: Out
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
@@ -42,7 +45,7 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Kind: StructuredBuffer
+# CHECK: Name: In
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x1,
@@ -50,7 +53,7 @@ DescriptorSets:
 # CHECK: 0x3
 # CHECK: ]
 
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Out
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x2,

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -16,9 +16,11 @@ DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32
+    Stride: 16
     Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003]
   - Name: Out
     Format: Hex32
+    Stride: 16
     ZeroInitSize: 16
 DescriptorSets:
   - Resources:

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -18,12 +18,14 @@ void main(uint GI : SV_GroupIndex) {
 //--- pipeline.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Buf
+    Format: Int32
+    Data: [ 0, 1, 2, 0, 4, 0, 1, 2, 3, 0, 4, 0]
 DescriptorSets:
   - Resources:
-    - Kind: RWStructuredBuffer
-      Format: Int32
-      RawSize: 24
-      Data: [ 0, 1, 2, 0, 4, 0, 1, 2, 3, 0, 4, 0]
+    - Name: Buf
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -21,6 +21,7 @@ DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32
+    Stride: 24
     Data: [ 0, 1, 2, 0, 4, 0, 1, 2, 3, 0, 4, 0]
 DescriptorSets:
   - Resources:

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -19,20 +19,23 @@ void main(uint GI : SV_GroupIndex) {
 //--- pipeline.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Hex32
+    Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003,
+           0x00000000, 0x3f800000, 0x40000000, 0x40400000]
+  - Name: Out
+    Format: Hex32
+    ZeroInitSize: 32
 DescriptorSets:
   - Resources:
-    - Kind: StructuredBuffer
-      Format: Hex32
-      RawSize: 32
-      Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003,
-             0x00000000, 0x3f800000, 0x40000000, 0x40400000]
+    - Name: In
+      Kind: StructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Hex32
-      RawSize: 32
-      ZeroInitSize: 32
+    - Name: Out
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
@@ -50,7 +53,7 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Kind: StructuredBuffer
+# CHECK: Name: In
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x1,
@@ -62,7 +65,7 @@ DescriptorSets:
 # CHECK: 0x40400000
 # CHECK: ]
 
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Out
 # CHECK: Data: [
 # CHECK: 0x0,
 # CHECK: 0x3F800000,

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -22,10 +22,12 @@ DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32
+    Stride: 32
     Data: [0x00000000, 0x00000001, 0x00000002, 0x00000003,
            0x00000000, 0x3f800000, 0x40000000, 0x40400000]
   - Name: Out
     Format: Hex32
+    Stride: 32
     ZeroInitSize: 32
 DescriptorSets:
   - Resources:

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -10,17 +10,22 @@ void main(uint3 TID : SV_GroupThreadID) {
 
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Data: [ 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8 ]
+  - Name: Out
+    Format: Float32
+    Data: [ 9.9, 10.1, 11.1, 12.2, 13.3, 14.4, 15.5, 16.6]
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Float32
-      Data: [ 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8 ]
+    - Name: In
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWBuffer
-      Format: Float32
-      Data: [ 9.9, 10.1, 11.1, 12.2, 13.3, 14.4, 15.5, 16.6]
+    - Name: Out
+      Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
@@ -37,9 +42,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Kind: RWBuffer
+# CHECK: Name: In
 # CHECK: Format: Float32
 # CHECK: Data: [ 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8 ]
-# CHECK: Kind: RWBuffer
+# CHECK: Name: Out
 # CHECK: Format: Float32
 # CHECK: Data: [ 5.4, 6.5, 7.6, 8.7, 9.8, 10.9, 12, 13.1 ]

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -11,17 +11,22 @@ void main(uint3 TID : SV_GroupThreadID) {
 
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Int32
+    Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
+  - Name: Out
+    Format: Int32
+    Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Int32
-      Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
+    - Name: In
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWBuffer
-      Format: Int32
-      Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
+    - Name: Out
+      Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
@@ -38,9 +43,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Kind: RWBuffer
+# CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
-# CHECK: Kind: RWBuffer
+# CHECK: Name: Out
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -22,23 +22,30 @@ void main(uint3 TID : SV_GroupThreadID) {
 
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Int32
+    Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
+  - Name: Out
+    Format: Int32
+    Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
+  - Name: cbuffer
+    Format: Int32
+    Data: [ 4, 0, 0, 0]
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Int32
-      Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
+    - Name: In
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWBuffer
-      Format: Int32
-      Data: [ 9, 10, 11, 12, 13, 14, 15, 16]
+    - Name: Out
+      Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
-    - Kind: ConstantBuffer
-      Format: Int32
-      Data: [ 4, 0, 0, 0]
+    - Name: cbuffer
+      Kind: ConstantBuffer
       DirectXBinding:
         Register: 0
         Space: 0
@@ -55,9 +62,9 @@ DescriptorSets:
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 
-# CHECK: Kind: RWBuffer
+# CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
-# CHECK: Kind: RWBuffer
+# CHECK: Name: Out
 # CHECK: Format: Int32
 # CHECK: Data: [ 4, 8, 12, 16, 20, 24, 28, 32 ]

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -17,12 +17,15 @@ DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32
+    Stride: 4
     Data: [ 1, -1, 2147483647, 0, -2147483648]
   - Name: Zeros
     Format: Int32
+    Stride: 4
     Data: [ 0, 0, 0, 0, 0]
   - Name: NegOnes
     Format: Int32
+    Stride: 4
     Data: [ -1, -1, -1, -1, -1]
 DescriptorSets:
   - Resources:
@@ -59,6 +62,7 @@ DescriptorSets:
 # CHECK: Name: Zeros
 # CHECK: Name: NegOnes
 # CHECK-NEXT: Format: Int32
+# CHECK-NEXT: Stride: 4
 # CHECK-NEXT: Data: [ -1, 1, -2147483647, 0
 
 # The last case here is definitly fun UB. -2147483648 / -1 on some GPUs returns

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -14,26 +14,30 @@ void main(uint3 TID : SV_GroupThreadID) {
 //--- pipeline.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Buf
+    Format: Int32
+    Data: [ 1, -1, 2147483647, 0, -2147483648]
+  - Name: Zeros
+    Format: Int32
+    Data: [ 0, 0, 0, 0, 0]
+  - Name: NegOnes
+    Format: Int32
+    Data: [ -1, -1, -1, -1, -1]
 DescriptorSets:
   - Resources:
-    - Kind: RWStructuredBuffer
-      Format: Int32
-      RawSize: 4
-      Data: [ 1, -1, 2147483647, 0, -2147483648]
+    - Name: Buf
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Int32
-      RawSize: 4
-      Data: [ 0, 0, 0, 0, 0]
+    - Name: Zeros
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Int32
-      RawSize: 4
-      Data: [ -1, -1, -1, -1, -1]
+    - Name: NegOnes
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
@@ -52,11 +56,9 @@ DescriptorSets:
 
 # Divide by-zero behavior seems to be erradic enough to call it undefined...
 
-# CHECK: Kind: RWStructuredBuffer
-# CHECK: Kind: RWStructuredBuffer
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Zeros
+# CHECK: Name: NegOnes
 # CHECK-NEXT: Format: Int32
-# CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ -1, 1, -2147483647, 0
 
 # The last case here is definitly fun UB. -2147483648 / -1 on some GPUs returns

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -16,19 +16,24 @@ void main(uint GI : SV_GroupIndex) {
 //--- simple.yaml
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Channels: 4
+    Data: [ 2, 4, 6, 8]
+  - Name: Out
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      Data: [ 2, 4, 6, 8]
+    - Name: In
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWBuffer
-      Format: Float32
-      Channels: 4
-      ZeroInitSize: 16
+    - Name: Out
+      Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 4

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -15,33 +15,38 @@ void main(uint3 TID : SV_GroupThreadID) {
 
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Nans
+    Format: Float32
+    Data: [ nan, nan, nan, nan ]
+  - Name: Infs
+    Format: Float32
+    Data: [ inf, inf, inf, inf ]
+  - Name: NegInfs
+    Format: Float32
+    Data: [ -inf, -inf, -inf, -inf ]
+  - Name: Mix
+    Format: Float32
+    Data: [ inf, -inf, nan, 0 ]
 DescriptorSets:
   - Resources:
-    - Kind: RWStructuredBuffer
-      Format: Float32
-      RawSize: 4
-      Data: [ nan, nan, nan, nan ]
+    - Name: Nans
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Float32
-      RawSize: 4
-      Data: [ inf, inf, inf, inf ]
+    - Name: Infs
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Float32
-      RawSize: 4
-      Data: [ -inf, -inf, -inf, -inf ]
+    - Name: NegInfs
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
-    - Kind: RWStructuredBuffer
-      Format: Float32
-      RawSize: 4
-      Data: [ inf, -inf, nan, 0 ]
+    - Name: Mix
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
@@ -79,21 +84,17 @@ DescriptorSets:
 
 # XFAIL: DirectX-WARP
 
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Nans
 # CHECK-NEXT: Format: Float32
-# CHECK-NEXT: RawSize: 4
 # METAL-NEXT: Data: [ 0, 0, 0, 0 ]
 # DX-NEXT: Data:
 # VULKAN-NEXT: Data:
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Infs
 # CHECK-NEXT: Format: Float32
-# CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ inf, inf, inf, inf ]
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: NegInfs
 # CHECK-NEXT: Format: Float32
-# CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ 0, 0, 0, 0 ]
-# CHECK: Kind: RWStructuredBuffer
+# CHECK: Name: Mix
 # CHECK-NEXT: Format: Float32
-# CHECK-NEXT: RawSize: 4
 # CHECK-NEXT: Data: [ inf, inf, inf, inf ]

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -18,11 +18,14 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 
 ---
 DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: value
+    Format: Int32
+    Data: [ 0, 0, 1, 2]
 DescriptorSets:
   - Resources:
-    - Kind: RWBuffer
-      Format: Int32
-      Data: [ 0, 0, 1, 2]
+    - Name: value
+      Kind: RWBuffer
       DirectXBinding:
         Register: 0
         Space: 0

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -136,13 +136,11 @@ int run() {
       Out->keep();
       return 0;
     }
-    for (const auto &S : PipelineDesc.Sets) {
-      for (const auto &R : S.Resources) {
-        if (R.OutputProps.Name == ImageOutput) {
-          ImageRef Img = ImageRef(R);
-          ExitOnErr(Image::writePNG(Img, OutputFilename));
-          return 0;
-        }
+    for (const auto &B : PipelineDesc.Buffers) {
+      if (B.Name == ImageOutput) {
+        ImageRef Img = ImageRef(B);
+        ExitOnErr(Image::writePNG(Img, OutputFilename));
+        return 0;
       }
     }
 


### PR DESCRIPTION
This change separates the definition of buffers of data from the resource bindings that connect them to shaders.

I believe this is a simplification that will make it easier to write tests because we'll have user-defined names that we can match on in the output.