### PR TITLE
Support shader stages in YAML

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -36,7 +36,7 @@ public:
   virtual const Capabilities &getCapabilities() = 0;
   virtual llvm::StringRef getAPIName() const = 0;
   virtual GPUAPI getAPI() const = 0;
-  virtual llvm::Error executeProgram(llvm::StringRef Program, Pipeline &P) = 0;
+  virtual llvm::Error executeProgram(Pipeline &P) = 0;
   virtual void printExtra(llvm::raw_ostream &OS) {}
 
   virtual ~Device() = 0;

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -15,11 +15,16 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <memory>
 #include <string>
 
 namespace offloadtest {
+
+enum class Stages {
+  Compute
+};
 
 enum class DataFormat {
   Hex8,
@@ -136,7 +141,15 @@ struct DescriptorSet {
   llvm::SmallVector<Resource> Resources;
 };
 
+struct Shader {
+  Stages Stage;
+  std::string Entry;
+  std::unique_ptr<llvm::MemoryBuffer> Shader;
+};
+
 struct Pipeline {
+  llvm::SmallVector<Shader> Shaders;
+
   int DispatchSize[3];
   llvm::SmallVector<Buffer> Buffers;
   llvm::SmallVector<DescriptorSet> Sets;
@@ -153,6 +166,7 @@ struct Pipeline {
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::DescriptorSet)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Resource)
 LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Buffer)
+LLVM_YAML_IS_SEQUENCE_VECTOR(offloadtest::Shader)
 
 namespace llvm {
 namespace yaml {
@@ -179,6 +193,10 @@ template <> struct MappingTraits<offloadtest::DirectXBinding> {
 
 template <> struct MappingTraits<offloadtest::OutputProperties> {
   static void mapping(IO &I, offloadtest::OutputProperties &P);
+};
+
+template <> struct MappingTraits<offloadtest::Shader> {
+  static void mapping(IO &I, offloadtest::Shader &B);
 };
 
 template <> struct ScalarEnumerationTraits<offloadtest::DataFormat> {
@@ -208,6 +226,14 @@ template <> struct ScalarEnumerationTraits<offloadtest::ResourceKind> {
     ENUM_CASE(RWBuffer);
     ENUM_CASE(RWStructuredBuffer);
     ENUM_CASE(ConstantBuffer);
+#undef ENUM_CASE
+  }
+};
+
+template <> struct ScalarEnumerationTraits<offloadtest::Stages> {
+  static void enumeration(IO &I, offloadtest::Stages &V) {
+#define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::Stages::Val)
+    ENUM_CASE(Compute);
 #undef ENUM_CASE
   }
 };

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -145,12 +145,12 @@ struct Shader {
   Stages Stage;
   std::string Entry;
   std::unique_ptr<llvm::MemoryBuffer> Shader;
+  int DispatchSize[3];
 };
 
 struct Pipeline {
   llvm::SmallVector<Shader> Shaders;
 
-  int DispatchSize[3];
   llvm::SmallVector<Buffer> Buffers;
   llvm::SmallVector<DescriptorSet> Sets;
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -710,7 +710,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error executeProgram(llvm::StringRef Program, Pipeline &P) override {
+  llvm::Error executeProgram(Pipeline &P) override {
     InvocationState State;
     llvm::outs() << "Configuring execution on device: " << Description << "\n";
     if (auto Err = createRootSignature(P, State))
@@ -719,7 +719,7 @@ public:
     if (auto Err = createDescriptorHeap(P, State))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
-    if (auto Err = createPSO(P, Program, State))
+    if (auto Err = createPSO(P, P.Shaders[0]->getBuffer(), State))
       return Err;
     llvm::outs() << "PSO created.\n";
     if (auto Err = createCommandStructures(State))

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -676,8 +676,9 @@ public:
       Handle.Offset(P.Sets[Idx].Resources.size(), Inc);
     }
 
-    IS.CmdList->Dispatch(P.DispatchSize[0], P.DispatchSize[1],
-                         P.DispatchSize[2]);
+    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+
+    IS.CmdList->Dispatch(DispatchSize[0], DispatchSize[1], DispatchSize[2]);
 
     for (auto &Out : IS.Resources)
       if (Out.Readback != nullptr) {
@@ -719,7 +720,7 @@ public:
     if (auto Err = createDescriptorHeap(P, State))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
-    if (auto Err = createPSO(P, P.Shaders[0]->getBuffer(), State))
+    if (auto Err = createPSO(P, P.Shaders[0].Shader->getBuffer(), State))
       return Err;
     llvm::outs() << "PSO created.\n";
     if (auto Err = createCommandStructures(State))

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -676,7 +676,8 @@ public:
       Handle.Offset(P.Sets[Idx].Resources.size(), Inc);
     }
 
-    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+    llvm::ArrayRef<int> DispatchSize =
+        llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
 
     IS.CmdList->Dispatch(DispatchSize[0], DispatchSize[1], DispatchSize[2]);
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -108,8 +108,8 @@ class MTLDevice : public offloadtest::Device {
     if (Error)
       return toError(Error);
 
-    IS.Fn =
-        IS.Lib->newFunction(NS::String::string(P.Entry.c_str(), NS::UTF8StringEncoding));
+    IS.Fn = IS.Lib->newFunction(
+        NS::String::string(P.Entry.c_str(), NS::UTF8StringEncoding));
     IS.PipelineState = Device->newComputePipelineState(IS.Fn, &Error);
     if (Error)
       return toError(Error);
@@ -189,8 +189,9 @@ class MTLDevice : public offloadtest::Device {
                               MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
 
     NS::UInteger TGS = IS.PipelineState->maxTotalThreadsPerThreadgroup();
-    MTL::Size GridSize = MTL::Size(TGS * P.DispatchSize[0], P.DispatchSize[1],
-                                   P.DispatchSize[2]);
+    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+    MTL::Size GridSize =
+        MTL::Size(TGS * DispatchSize[0], DispatchSize[1], DispatchSize[2]);
     MTL::Size GroupSize(TGS, 1, 1);
 
     CmdEncoder->dispatchThreads(GridSize, GroupSize);

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -189,7 +189,8 @@ class MTLDevice : public offloadtest::Device {
                               MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
 
     NS::UInteger TGS = IS.PipelineState->maxTotalThreadsPerThreadgroup();
-    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+    llvm::ArrayRef<int> DispatchSize =
+        llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
     MTL::Size GridSize =
         MTL::Size(TGS * DispatchSize[0], DispatchSize[1], DispatchSize[2]);
     MTL::Size GroupSize(TGS, 1, 1);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -604,8 +604,9 @@ public:
     vkCmdBindDescriptorSets(IS.CmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                             IS.PipelineLayout, 0, IS.DescriptorSets.size(),
                             IS.DescriptorSets.data(), 0, 0);
-    vkCmdDispatch(IS.CmdBuffer, P.DispatchSize[0], P.DispatchSize[1],
-                  P.DispatchSize[2]);
+    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+    vkCmdDispatch(IS.CmdBuffer, DispatchSize[0], DispatchSize[1],
+                  DispatchSize[2]);
 
     for (auto &UAV : IS.Buffers) {
       VkBufferMemoryBarrier Barrier = {};
@@ -714,7 +715,7 @@ public:
     if (auto Err = createDescriptorSets(P, State))
       return Err;
     llvm::outs() << "Descriptor sets created.\n";
-    if (auto Err = createShaderModule(P.Shaders[0]->getBuffer(), State))
+    if (auto Err = createShaderModule(P.Shaders[0].Shader->getBuffer(), State))
       return Err;
     llvm::outs() << "Shader module created.\n";
     if (auto Err = createPipeline(P, State))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -570,7 +570,7 @@ public:
     StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     StageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     StageInfo.module = IS.Shader;
-    StageInfo.pName = "main";
+    StageInfo.pName = P.Shaders[0].Entry;
 
     VkComputePipelineCreateInfo PipelineCreateInfo = {};
     PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
@@ -691,7 +691,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error executeProgram(llvm::StringRef Program, Pipeline &P) override {
+  llvm::Error executeProgram(Pipeline &P) override {
     InvocationState State;
     if (auto Err = createDevice(State))
       return Err;
@@ -714,7 +714,7 @@ public:
     if (auto Err = createDescriptorSets(P, State))
       return Err;
     llvm::outs() << "Descriptor sets created.\n";
-    if (auto Err = createShaderModule(Program, State))
+    if (auto Err = createShaderModule(P.Shaders[0]->getBuffer(), State))
       return Err;
     llvm::outs() << "Shader module created.\n";
     if (auto Err = createPipeline(P, State))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -604,7 +604,8 @@ public:
     vkCmdBindDescriptorSets(IS.CmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                             IS.PipelineLayout, 0, IS.DescriptorSets.size(),
                             IS.DescriptorSets.data(), 0, 0);
-    ArrayRef<int> DispatchSize = ArrayRef<int>(P.Shaders[0].DispatchSize);
+    llvm::ArrayRef<int> DispatchSize =
+        llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
     vkCmdDispatch(IS.CmdBuffer, DispatchSize[0], DispatchSize[1],
                   DispatchSize[2]);
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -570,7 +570,7 @@ public:
     StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     StageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     StageInfo.module = IS.Shader;
-    StageInfo.pName = P.Shaders[0].Entry;
+    StageInfo.pName = P.Shaders[0].Entry.c_str();
 
     VkComputePipelineCreateInfo PipelineCreateInfo = {};
     PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -18,9 +18,13 @@ namespace yaml {
 void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
                                                    offloadtest::Pipeline &P) {
   MutableArrayRef<int> MutableDispatchSize(P.DispatchSize);
-  I.mapRequired("DispatchSize", MutableDispatchSize);
+  I.mapRequired("Shaders", P.Shaders);
   I.mapRequired("Buffers", P.Buffers);
   I.mapRequired("DescriptorSets", P.Sets);
+
+  // Stage-specific data, not sure if this should be optional
+  // or moved into the Shaders structure.
+  I.mapRequired("DispatchSize", MutableDispatchSize);
 
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
@@ -108,6 +112,12 @@ void MappingTraits<offloadtest::OutputProperties>::mapping(
   I.mapRequired("Height", P.Height);
   I.mapRequired("Width", P.Width);
   I.mapRequired("Depth", P.Depth);
+}
+
+void MappingTraits<offloadtest::Shader>::mapping(IO &I,
+  offloadtest::Shader &S) {
+    I.mapRequired("Stage", S.Stage);
+    I.mapRequired("Entry", S.Entry);
 }
 } // namespace yaml
 } // namespace llvm

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -17,14 +17,9 @@ namespace llvm {
 namespace yaml {
 void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
                                                    offloadtest::Pipeline &P) {
-  MutableArrayRef<int> MutableDispatchSize(P.DispatchSize);
   I.mapRequired("Shaders", P.Shaders);
   I.mapRequired("Buffers", P.Buffers);
   I.mapRequired("DescriptorSets", P.Sets);
-
-  // Stage-specific data, not sure if this should be optional
-  // or moved into the Shaders structure.
-  I.mapRequired("DispatchSize", MutableDispatchSize);
 
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
@@ -118,6 +113,13 @@ void MappingTraits<offloadtest::Shader>::mapping(IO &I,
   offloadtest::Shader &S) {
     I.mapRequired("Stage", S.Stage);
     I.mapRequired("Entry", S.Entry);
+
+    if (S.Stage == Stages::Compute) {
+      // Stage-specific data, not sure if this should be optional
+      // or moved into the Shaders structure.
+      MutableArrayRef<int> MutableDispatchSize(S.DispatchSize);
+      I.mapRequired("DispatchSize", MutableDispatchSize);
+    }
 }
 } // namespace yaml
 } // namespace llvm

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -20,7 +20,7 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -17,6 +17,9 @@ void main(uint GI : SV_GroupIndex) {
 }
 //--- DescriptorSets.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -57,7 +57,7 @@ const static int Dimension = 4096;
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [16384, 1, 1]
+    DispatchSize: [16384, 1, 1]
 Buffers:
   - Name: Tex
     Format: Float32

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -54,6 +54,9 @@ const static int Dimension = 4096;
 
 //--- pipeline.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [16384, 1, 1]
 Buffers:
   - Name: Tex

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -12,6 +12,9 @@ void main(uint GI : SV_GroupIndex) {
 }
 //--- pipeline.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -15,7 +15,7 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -20,7 +20,7 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -17,6 +17,9 @@ void main(uint GI : SV_GroupIndex) {
 }
 //--- pipeline.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -21,7 +21,7 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Hex32

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -18,6 +18,9 @@ void main(uint GI : SV_GroupIndex) {
 }
 //--- pipeline.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -12,7 +12,7 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -9,6 +9,9 @@ void main(uint3 TID : SV_GroupThreadID) {
 //--- pipeline.yaml
 
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -3,13 +3,16 @@ RWBuffer<int> In : register(u0);
 RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
-void main(uint3 TID : SV_GroupThreadID) {
+void CSMain(uint3 TID : SV_GroupThreadID) {
   Out[TID.x] = In[TID.x];
 }
 
 //--- pipeline.yaml
 
 ---
+Shaders:
+  - Stage: Compute
+    Entry: CSMain
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
@@ -35,11 +38,11 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
-# RUN: %if DirectX %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
+# RUN: %if DirectX %{ dxc -T cs_6_0 -E CSMain -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if DirectX %{ %offloader %t/pipeline.yaml %t.dxil | FileCheck %s %}
-# RUN: %if Vulkan %{ dxc -T cs_6_0 -spirv -Fo %t.spv %t/source.hlsl %}
+# RUN: %if Vulkan %{ dxc -T cs_6_0 -E CSMain -spirv -Fo %t.spv %t/source.hlsl %}
 # RUN: %if Vulkan %{ %offloader %t/pipeline.yaml %t.spv | FileCheck %s %}
-# RUN: %if Metal %{ dxc -T cs_6_0 -Fo %t.dxil %t/source.hlsl %}
+# RUN: %if Metal %{ dxc -T cs_6_0 -E CSMain -Fo %t.dxil %t/source.hlsl %}
 # RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.metallib %}
 # RUN: %if Metal %{ %offloader %t/pipeline.yaml %t.metallib | FileCheck %s %}
 

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -13,7 +13,7 @@ void CSMain(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: CSMain
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -24,7 +24,7 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Int32

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -21,6 +21,9 @@ void main(uint3 TID : SV_GroupThreadID) {
 //--- pipeline.yaml
 
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -16,7 +16,7 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf
     Format: Int32

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -13,6 +13,9 @@ void main(uint3 TID : SV_GroupThreadID) {
 }
 //--- pipeline.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Buf

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -15,6 +15,9 @@ void main(uint GI : SV_GroupIndex) {
 }
 //--- simple.yaml
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -18,7 +18,7 @@ void main(uint GI : SV_GroupIndex) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
     Format: Float32

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -17,7 +17,7 @@ void main(uint3 TID : SV_GroupThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Nans
     Format: Float32

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -14,6 +14,9 @@ void main(uint3 TID : SV_GroupThreadID) {
 //--- pipeline.yaml
 
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: Nans

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -17,6 +17,9 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 //--- pipeline.yaml
 
 ---
+Shaders:
+  - Stage: Compute
+    Entry: main
 DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -20,7 +20,7 @@ void main(uint3 threadID : SV_DispatchThreadID) {
 Shaders:
   - Stage: Compute
     Entry: main
-DispatchSize: [1, 1, 1]
+    DispatchSize: [1, 1, 1]
 Buffers:
   - Name: value
     Format: Int32


### PR DESCRIPTION
This update alters the YAML representation to capture the shader stage and entry function names. Previously I had hacked in `main` in a few places and we surprisingly haven't tripped over it.

I've updated the `TestPipeline` test to use `CSMain` to verify that we can actually change the entry point's name and have everything still work.