### PR TITLE
Simplify Metal test runs

### DIFF
--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -60,8 +60,6 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/DescriptorSets.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/DescriptorSets.yaml %t.o | FileCheck %s
 
 # CHECK: Data:

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -100,7 +100,5 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o -r Tex -o %t/output.png
 # RUN: imgdiff %t/output.png %goldenimage_dir/hlsl/Basic/Mandelbrot.png -rules %t/rules.yaml

--- a/test/Basic/StructuredBuffer-SRV.test
+++ b/test/Basic/StructuredBuffer-SRV.test
@@ -42,8 +42,6 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: In

--- a/test/Basic/StructuredBuffer-packed.test
+++ b/test/Basic/StructuredBuffer-packed.test
@@ -40,8 +40,6 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
 # RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 

--- a/test/Basic/StructuredBuffer.test
+++ b/test/Basic/StructuredBuffer.test
@@ -49,8 +49,6 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 # XFAIL: DXC-Vulkan
 

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -38,8 +38,6 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: In

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -39,8 +39,6 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -E CSMain -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: In

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -58,8 +58,6 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: In

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -53,8 +53,6 @@ DescriptorSets:
 # UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # Divide by-zero behavior seems to be erradic enough to call it undefined...

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -45,8 +45,6 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s
 
 # CHECK: Data:

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -61,8 +61,6 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
 # RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.1 -Fo %t.o %t/source.hlsl %}
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # The behavior of this operation is consistent on Metal, so the test verifies that behavior.

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -39,8 +39,6 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
 # RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.1 -Fo %t.o %t/source.hlsl %}
-# RUN: %if Metal %{ mv %t.o %t.dxil %}
-# RUN: %if Metal %{ metal-shaderconverter %t.dxil -o=%t.o %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # XFAIL: Vulkan-NV

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -51,6 +51,8 @@ else:
 ExtraCompilerArgs = []
 if config.offloadtest_enable_vulkan:
   ExtraCompilerArgs = ['-spirv']
+if config.offloadtest_enable_metal:
+  ExtraCompilerArgs = ['-metal']
 
 HLSLCompiler = ''
 if config.offloadtest_test_clang:


### PR DESCRIPTION
This adapts the test suite to use the clang and DXC `-metal` flag when running the tests. This significantly simplifies the run lines, but requires bleeding edge DXC and Clang.