### PR TITLE
[DX] Use the root signature from a shader if present

### DIFF
--- a/lib/API/CMakeLists.txt
+++ b/lib/API/CMakeLists.txt
@@ -27,7 +27,7 @@ add_offloadtest_library(API
 
 target_include_directories(OffloadTestAPI SYSTEM BEFORE ${api_headers})
 
-target_link_libraries(OffloadTestAPI INTERFACE OffloadTestSupport ${api_libraries})
+target_link_libraries(OffloadTestAPI INTERFACE LLVMSupport LLVMObject OffloadTestSupport ${api_libraries})
 if (TARGET DIRECTX_HEADERS)
   add_dependencies(OffloadTestAPI DIRECTX_HEADERS)
 endif()

--- a/test/M3/RootSignatures/DescriptorTables.test
+++ b/test/M3/RootSignatures/DescriptorTables.test
@@ -1,0 +1,67 @@
+#--- source.hlsl
+
+struct Input {
+  float4 A;
+  float4 B;
+};
+
+StructuredBuffer<Input> In : register(t2, space0);
+RWBuffer<float4> Out1 : register(u1, space4);
+RWBuffer<float4> Out2 : register(u2, space4);
+
+[RootSignature("DescriptorTable(SRV(t2), UAV(u1, space=4), UAV(u2, space=4, numdescriptors=1))")]
+[numthreads(1,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out1[GI] = In[GI].A * In[GI].B;
+  Out2[GI] = In[GI].A * In[GI].B * 2;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Stride: 32
+    Data: [ 2, 4, 6, 8, 10, 12, 14, 16]
+  - Name: Out1
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
+  - Name: Out2
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+    - Name: Out1
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 4
+    - Name: Out2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 4
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+
+# CHECK: Data:
+# CHECK-LABEL: Name: Out1
+# CHECK: Data: [ 20, 48, 84, 128 ]
+# CHECK-LABEL: Name: Out2
+# CHECK: Data: [ 40, 96, 168, 256 ]

--- a/test/M3/RootSignatures/TwoDescriptorTables.test
+++ b/test/M3/RootSignatures/TwoDescriptorTables.test
@@ -1,0 +1,68 @@
+#--- source.hlsl
+
+struct Input {
+  float4 A;
+  float4 B;
+};
+
+StructuredBuffer<Input> In : register(t2, space0);
+RWBuffer<float4> Out1 : register(u1, space4);
+RWBuffer<float4> Out2 : register(u2, space4);
+
+[RootSignature("DescriptorTable(SRV(t2), UAV(u1, space=4)), DescriptorTable(UAV(u2, space=4, numdescriptors=1))")]
+[numthreads(1,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out1[GI] = In[GI].A * In[GI].B;
+  Out2[GI] = In[GI].A * In[GI].B * 2;
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Stride: 32
+    Data: [ 2, 4, 6, 8, 10, 12, 14, 16]
+  - Name: Out1
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
+  - Name: Out2
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 16
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+    - Name: Out1
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 4
+  - Resources:
+    - Name: Out2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 4
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+
+# CHECK: Data:
+# CHECK-LABEL: Name: Out1
+# CHECK: Data: [ 20, 48, 84, 128 ]
+# CHECK-LABEL: Name: Out2
+# CHECK: Data: [ 40, 96, 168, 256 ]

--- a/test/M3/RootSignatures/lit.local.cfg
+++ b/test/M3/RootSignatures/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'DirectX' not in config.available_features:
+  config.unsupported = True


### PR DESCRIPTION
This updates the DX device code to inspect the shader for a precompiled root signature and use that instead of building a root signature from scratch.

Still missing support for root descriptors, root constants and lots of tests, but this is a good starting base.