### PR TITLE
[NFC] Fix typo in NumberParameters test description

### DIFF
--- a/test/M3/RootSignatures/NumberParameters.test
+++ b/test/M3/RootSignatures/NumberParameters.test
@@ -19,7 +19,7 @@ RWStructuredBuffer<Output> Out2 : register(u2);
 
 // Root signature to test edge-cases of specify number arguments:
 //  - Maximum valid register value (0xfffffffe = 4294967294)
-//  - Maximum valid register space value (0x7fffffff = 2147483647)
+//  - Maximum valid register space value (0xffffffef = 4294967279)
 //  - Maximum valid num32BitConstants value
 //    (61 = 64 - # of used DWORDS for other params)
 //  - Using (un)signed integer parameter values


### PR DESCRIPTION
- The register spaces 0xfffffff0 to 0xffffffff are reserved, the original testcase is meant to demonstrate that we can use the valid value of 0xfffffff0 - 1 = 0xffffffef = 4294967279, which it does
- However, the comment describing the testcase specifies the wrong value

This commit resolves the discrepancy by fixing up the comment typo as noted here: https://github.com/llvm-beanz/offload-test-suite/pull/45#discussion_r2017664530