### PR TITLE
Add test for structures in cbuffers

### DIFF
--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -1,0 +1,134 @@
+#--- source.hlsl
+
+struct X {
+  int a1;
+};
+
+struct Y : X {
+  int2 a2;
+};
+
+struct Z {
+  X xs[2];
+  Y y;
+};
+
+cbuffer CBStructs : register(b0) {
+  X x1;
+  X x2;
+  Y y;
+  Z zs[2];
+};
+
+struct S {
+  int x1a1;
+  int x2a1;
+  int ya1;
+  int2 ya2;
+  int z1x1a1;
+  int z1x2a1;
+  int z1ya1;
+  int2 z1ya2;
+  int z2x1a1;
+  int z2x2a1;
+  int z2ya1;
+  int2 z2ya2;
+};
+
+RWStructuredBuffer<S> Out : register(u0);
+
+[numthreads(1,1,1)]
+void main() {
+ Out[0].x1a1 = x1.a1;
+ Out[0].x2a1 = x2.a1;
+ Out[0].ya1 = y.a1;
+ Out[0].ya2 = y.a2;
+ Out[0].z1x1a1 = zs[0].xs[0].a1;
+ Out[0].z1x2a1 = zs[0].xs[1].a1;
+ Out[0].z1ya1 = zs[0].y.a1;
+ Out[0].z1ya2 = zs[0].y.a2;
+ Out[0].z2x1a1 = zs[1].xs[0].a1;
+ Out[0].z2x2a1 = zs[1].xs[1].a1;
+ Out[0].z2ya1 = zs[1].y.a1;
+ Out[0].z2ya2 = zs[1].y.a2;
+}
+
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: CBVectors
+    Format: Hex32
+    Data: [
+      0x1, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x2, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x3, 0x4, 0x5, 0x5A5A5A5A,
+      0x6, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x7, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0x8, 0x9, 0xA, 0x5A5A5A5A,
+      0xB, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0xC, 0x5A5A5A5A, 0x5A5A5A5A, 0x5A5A5A5A,
+      0xD, 0xE, 0xF, 0x5A5A5A5A,
+    ]
+  - Name: Out
+    Format: Hex32
+    Stride: 60
+    ZeroInitSize: 60
+DescriptorSets:
+  - Resources:
+    - Name: CBVectors
+      Kind: ConstantBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+...
+#--- end
+
+# DXC's vulkan support does not layout cbuffers compatibly with DXIL
+# UNSUPPORTED: Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+
+# CHECK: - Name: CBVectors
+# CHECK:   Format: Hex32
+
+# CHECK: - Name: Out
+# CHECK:   Format: Hex32
+# CHECK:   Data: [
+# CHECK:     0x1,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0x2,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0x3,
+# CHECK:     0x4,
+# CHECK:     0x5,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0x6,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0x7,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0x8,
+# CHECK:     0x9,
+# CHECK:     0xA,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0xB,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0xC,
+# CHECK-NOT: 0x5A5A5A5A,
+# CHECK:     0xD,
+# CHECK:     0xE,
+# CHECK:     0xF
+# CHECK-NOT: 0x5A5A5A5A
+# CHECK:   ]


### PR DESCRIPTION
The layout and packing rules for constant variables in DirectX is quite weird. The official docs can be found [here](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules). There's also a handy visualization tool [here](https://maraneshi.github.io/HLSL-ConstantBufferLayoutVisualizer/).