### PR TITLE
Update CBuffer tests to work with clang

### DIFF
--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -59,6 +59,9 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
+# https://github.com/llvm/llvm-project/issues/110722
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -63,6 +63,9 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
+# https://github.com/llvm/llvm-project/issues/110722
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -63,6 +63,9 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
+# https://github.com/llvm/llvm-project/issues/110722
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -55,9 +55,6 @@ DescriptorSets:
 
 # REQUIRES: Half, Int16
 
-# See https://github.com/llvm-beanz/offload-test-suite/issues/52
-# XFAIL: Vulkan-Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
 
-cbuffer CBVectors {
+cbuffer CBVectors : register(b0) {
   float16_t2 b1;
   uint16_t3 b2;
 }

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -1,6 +1,6 @@
 #--- source.hlsl
 
-cbuffer CBVectors {
+cbuffer CBVectors : register(b0) {
   float3 b1;
   int4 b2;
   uint2 b3;


### PR DESCRIPTION
- Avoid implicit bindings.
- Disable tests that do array casts for now.