### PR TITLE
Set the stride correctly for structured buffers in the DX API

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -415,7 +415,8 @@ public:
         EltFormat,
         D3D12_SRV_DIMENSION_BUFFER,
         D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-        {D3D12_BUFFER_SRV{0, NumElts, static_cast<uint32_t>(R.size()),
+        {D3D12_BUFFER_SRV{0, NumElts,
+                          static_cast<uint32_t>(R.BufferPtr->Stride),
                           D3D12_BUFFER_SRV_FLAG_NONE}}};
 
     llvm::outs() << "SRV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize

--- a/test/Feature/StructuredBuffer/stride.test
+++ b/test/Feature/StructuredBuffer/stride.test
@@ -1,0 +1,53 @@
+#--- source.hlsl
+struct S {
+  float4 i;
+};
+
+StructuredBuffer<float4> In : register(t0);
+RWStructuredBuffer<S> Out : register(u1);
+
+[numthreads(1,1,2)]
+void main(uint GI : SV_GroupIndex) {
+  Out[GI].i = In[GI];
+}
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Stride: 32
+    Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+  - Name: Out
+    Format: Float32
+    Stride: 4
+    ZeroInitSize: 32
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+...
+#--- end
+
+# UNSUPPORTED: Clang-Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+
+# CHECK: Name: In
+# CHECK: Data: [
+
+# CHECK: Name: Out
+# CHECK: Data: [ 1, 2, 3, 4, 5, 6, 7, 8 ]


### PR DESCRIPTION
Using `size` here happens to work if we have exactly one object in the buffer, so most of the existing tests don't go wrong here.