### PR TITLE
[VK] Enable RWBuffer tests in Clang

### DIFF
--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -55,7 +55,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/DescriptorSets.hlsl
 # RUN: %offloader %t/DescriptorSets.yaml %t.o | FileCheck %s

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -36,7 +36,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -E CSMain -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -43,7 +43,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s


### PR DESCRIPTION
Clang supports RWBuffer for Vulkan now, so these tests should pass!