### PR TITLE
Add support and tests for `ByteAddressBuffer` for DirectX

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -43,8 +43,10 @@ enum class DataFormat {
 enum class ResourceKind {
   Buffer,
   StructuredBuffer,
+  ByteAddressBuffer,
   RWBuffer,
   RWStructuredBuffer,
+  RWByteAddressBuffer,
   ConstantBuffer,
 };
 
@@ -112,10 +114,32 @@ struct Resource {
       return false;
     case ResourceKind::StructuredBuffer:
     case ResourceKind::RWStructuredBuffer:
+    case ResourceKind::ByteAddressBuffer:
+    case ResourceKind::RWByteAddressBuffer:
     case ResourceKind::ConstantBuffer:
       return true;
     }
     llvm_unreachable("All cases handled");
+  }
+
+  bool isByteAddressBuffer() const {
+    switch (Kind) {
+    case ResourceKind::ByteAddressBuffer:
+    case ResourceKind::RWByteAddressBuffer:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  bool isStructuredBuffer() const {
+    switch (Kind) {
+    case ResourceKind::StructuredBuffer:
+    case ResourceKind::RWStructuredBuffer:
+      return true;
+    default:
+      return false;
+    }
   }
 
   uint32_t getElementSize() const { return BufferPtr->getElementSize(); }
@@ -126,10 +150,12 @@ struct Resource {
     switch (Kind) {
     case ResourceKind::Buffer:
     case ResourceKind::StructuredBuffer:
+    case ResourceKind::ByteAddressBuffer:
     case ResourceKind::ConstantBuffer:
       return false;
     case ResourceKind::RWBuffer:
     case ResourceKind::RWStructuredBuffer:
+    case ResourceKind::RWByteAddressBuffer:
       return true;
     }
     llvm_unreachable("All cases handled");
@@ -274,8 +300,10 @@ template <> struct ScalarEnumerationTraits<offloadtest::ResourceKind> {
 #define ENUM_CASE(Val) I.enumCase(V, #Val, offloadtest::ResourceKind::Val)
     ENUM_CASE(Buffer);
     ENUM_CASE(StructuredBuffer);
+    ENUM_CASE(ByteAddressBuffer);
     ENUM_CASE(RWBuffer);
     ENUM_CASE(RWStructuredBuffer);
+    ENUM_CASE(RWByteAddressBuffer);
     ENUM_CASE(ConstantBuffer);
 #undef ENUM_CASE
   }

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -77,12 +77,6 @@ static DXGI_FORMAT getRawDXFormat(Resource &R) {
     return DXGI_FORMAT_UNKNOWN;
 
   switch (R.BufferPtr->Format) {
-  case DataFormat::Hex8:
-    return DXGI_FORMAT_R8_TYPELESS;
-  case DataFormat::Hex16:
-  case DataFormat::UInt16:
-  case DataFormat::Int16:
-    return DXGI_FORMAT_R16_TYPELESS;
   case DataFormat::Hex32:
   case DataFormat::UInt32:
   case DataFormat::Int32:

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -440,11 +440,10 @@ public:
         EltFormat,
         D3D12_SRV_DIMENSION_BUFFER,
         D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
-        {D3D12_BUFFER_SRV{0, NumElts,
-            R.isStructuredBuffer() ? EltSize : 0,
-            R.isByteAddressBuffer() ? D3D12_BUFFER_SRV_FLAG_RAW
-                                    : D3D12_BUFFER_SRV_FLAG_NONE}
-        }};
+        {D3D12_BUFFER_SRV{0, NumElts, R.isStructuredBuffer() ? EltSize : 0,
+                          R.isByteAddressBuffer()
+                              ? D3D12_BUFFER_SRV_FLAG_RAW
+                              : D3D12_BUFFER_SRV_FLAG_NONE}}};
 
     llvm::outs() << "SRV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
                  << " NumElts = " << NumElts << "\n";
@@ -532,7 +531,7 @@ public:
     return ResourceSet{UploadBuffer, Buffer, ReadBackBuffer};
   }
 
-void bindUAV(Resource &R, InvocationState &IS, const uint32_t HeapIdx,
+  void bindUAV(Resource &R, InvocationState &IS, const uint32_t HeapIdx,
                ComPtr<ID3D12Resource> Buffer) {
     const uint32_t EltSize = R.getElementSize();
     const uint32_t NumElts = R.size() / EltSize;
@@ -542,10 +541,10 @@ void bindUAV(Resource &R, InvocationState &IS, const uint32_t HeapIdx,
     const D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {
         EltFormat,
         D3D12_UAV_DIMENSION_BUFFER,
-        {D3D12_BUFFER_UAV{0, NumElts, 
-            R.isStructuredBuffer() ? EltSize : 0, 0,
-            R.isByteAddressBuffer() ? D3D12_BUFFER_UAV_FLAG_RAW
-                                    : D3D12_BUFFER_UAV_FLAG_NONE}}};
+        {D3D12_BUFFER_UAV{0, NumElts, R.isStructuredBuffer() ? EltSize : 0, 0,
+                          R.isByteAddressBuffer()
+                              ? D3D12_BUFFER_UAV_FLAG_RAW
+                              : D3D12_BUFFER_UAV_FLAG_NONE}}};
 
     llvm::outs() << "UAV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
                  << " NumElts = " << NumElts << "\n";

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -72,6 +72,28 @@ static DXGI_FORMAT getDXFormat(DataFormat Format, int Channels) {
   return DXGI_FORMAT_UNKNOWN;
 }
 
+static DXGI_FORMAT getRawDXFormat(Resource &R) {
+  if (!R.isByteAddressBuffer())
+    return DXGI_FORMAT_UNKNOWN;
+
+  switch (R.BufferPtr->Format) {
+  case DataFormat::Hex8:
+    return DXGI_FORMAT_R8_TYPELESS;
+  case DataFormat::Hex16:
+  case DataFormat::UInt16:
+  case DataFormat::Int16:
+    return DXGI_FORMAT_R16_TYPELESS;
+  case DataFormat::Hex32:
+  case DataFormat::UInt32:
+  case DataFormat::Int32:
+  case DataFormat::Float32:
+    return DXGI_FORMAT_R32_TYPELESS;
+  default:
+    llvm_unreachable("Unsupported Resource format specified");
+  }
+  return DXGI_FORMAT_UNKNOWN;
+}
+
 namespace {
 
 enum DXResourceKind { UAV, SRV, CBV };
@@ -80,10 +102,12 @@ DXResourceKind getDXKind(offloadtest::ResourceKind RK) {
   switch (RK) {
   case ResourceKind::Buffer:
   case ResourceKind::StructuredBuffer:
+  case ResourceKind::ByteAddressBuffer:
     return SRV;
 
   case ResourceKind::RWStructuredBuffer:
   case ResourceKind::RWBuffer:
+  case ResourceKind::RWByteAddressBuffer:
     return UAV;
 
   case ResourceKind::ConstantBuffer:
@@ -410,15 +434,17 @@ public:
     const uint32_t EltSize = R.getElementSize();
     const uint32_t NumElts = R.size() / EltSize;
     DXGI_FORMAT EltFormat =
-        R.isRaw() ? DXGI_FORMAT_UNKNOWN
+        R.isRaw() ? getRawDXFormat(R)
                   : getDXFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
     const D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = {
         EltFormat,
         D3D12_SRV_DIMENSION_BUFFER,
         D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING,
         {D3D12_BUFFER_SRV{0, NumElts,
-                          static_cast<uint32_t>(R.BufferPtr->Stride),
-                          D3D12_BUFFER_SRV_FLAG_NONE}}};
+            R.isStructuredBuffer() ? EltSize : 0,
+            R.isByteAddressBuffer() ? D3D12_BUFFER_SRV_FLAG_RAW
+                                    : D3D12_BUFFER_SRV_FLAG_NONE}
+        }};
 
     llvm::outs() << "SRV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
                  << " NumElts = " << NumElts << "\n";
@@ -506,18 +532,20 @@ public:
     return ResourceSet{UploadBuffer, Buffer, ReadBackBuffer};
   }
 
-  void bindUAV(Resource &R, InvocationState &IS, const uint32_t HeapIdx,
+void bindUAV(Resource &R, InvocationState &IS, const uint32_t HeapIdx,
                ComPtr<ID3D12Resource> Buffer) {
     const uint32_t EltSize = R.getElementSize();
     const uint32_t NumElts = R.size() / EltSize;
     DXGI_FORMAT EltFormat =
-        R.isRaw() ? DXGI_FORMAT_UNKNOWN
+        R.isRaw() ? getRawDXFormat(R)
                   : getDXFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
     const D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {
         EltFormat,
         D3D12_UAV_DIMENSION_BUFFER,
-        {D3D12_BUFFER_UAV{0, NumElts, R.isRaw() ? R.getElementSize() : 0, 0,
-                          D3D12_BUFFER_UAV_FLAG_NONE}}};
+        {D3D12_BUFFER_UAV{0, NumElts, 
+            R.isStructuredBuffer() ? EltSize : 0, 0,
+            R.isByteAddressBuffer() ? D3D12_BUFFER_UAV_FLAG_RAW
+                                    : D3D12_BUFFER_UAV_FLAG_NONE}}};
 
     llvm::outs() << "UAV: HeapIdx = " << HeapIdx << " EltSize = " << EltSize
                  << " NumElts = " << NumElts << "\n";

--- a/test/Feature/RawBuffers/ByteAddressBuffers.test
+++ b/test/Feature/RawBuffers/ByteAddressBuffers.test
@@ -3,7 +3,13 @@
 // This test checks that we will get the expected values from invoking
 // various `Load*` and `Store` methods on `[RW]ByteAddressBuffer`.
 
-ByteAddressBuffer In : register(t0);
+// The expected behaviour is to load the values in `In1` and `In2` at the given
+// byte-offset, add them, and store the result at the respective offset in
+// `Out`. We expect each load and store to only access mapped resource data, so
+// `CheckAccessFullyMapped` should always return `true = 1`.
+
+ByteAddressBuffer In1 : register(t0);
+ByteAddressBuffer In2 : register(t1);
 RWByteAddressBuffer Out : register(u0);
 RWBuffer<uint> MappedBuf : register(u0, space1);
 
@@ -11,21 +17,25 @@ RWBuffer<uint> MappedBuf : register(u0, space1);
 void main() {
   uint status;
 
-  uint u1 = In.Load(0, status);
+  uint u1 = In1.Load(0, status);
   MappedBuf[0] = CheckAccessFullyMapped(status);
-  Out.Store(0, u1);
+  uint v1 = In2.Load(0);
+  Out.Store(0, u1 + v1);
 
-  uint2 u2 = In.Load2(16, status);
+  uint2 u2 = In1.Load2(16, status);
   MappedBuf[1] = CheckAccessFullyMapped(status);
-  Out.Store2(16, u2);
+  uint2 v2 = In2.Load2(16);
+  Out.Store2(16, u2 + v2);
 
-  uint3 u3 = In.Load3(32, status);
+  uint3 u3 = In1.Load3(32, status);
   MappedBuf[2] = CheckAccessFullyMapped(status);
-  Out.Store3(32, u3);
+  uint3 v3 = In2.Load3(32);
+  Out.Store3(32, u3 + v3);
 
-  uint4 u4 = In.Load4(48, status);
+  uint4 u4 = In1.Load4(48, status);
   MappedBuf[3] = CheckAccessFullyMapped(status);
-  Out.Store4(48, u4);
+  uint4 v4 = In2.Load4(48);
+  Out.Store4(48, u4 + v4);
 }
 
 //--- pipeline.yaml
@@ -37,12 +47,17 @@ Shaders:
     DispatchSize: [4, 1, 1]
 
 Buffers:
-  - Name: InBuf
+  - Name: In1Buf
     Format: Int32
     Data: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
 
+  - Name: In2Buf
+    Format: Hex32
+    Data: [ 0x100, 0x200, 0x300, 0x400, 0x500, 0x600, 0x700, 0x800, 
+            0x900, 0xA00, 0xB00, 0xC00, 0xD00, 0xE00, 0xF00, 0x1000 ]
+
   - Name: OutBuf
-    Format: Int32
+    Format: Hex32
     ZeroInitSize: 64
 
   - Name: MappedBuf
@@ -51,10 +66,16 @@ Buffers:
 
 DescriptorSets:
   - Resources:
-    - Name: InBuf
+    - Name: In1Buf
       Kind: ByteAddressBuffer
       DirectXBinding:
         Register: 0
+        Space: 0
+
+    - Name: In2Buf
+      Kind: ByteAddressBuffer
+      DirectXBinding:
+        Register: 1
         Space: 0
 
     - Name: OutBuf
@@ -72,16 +93,16 @@ DescriptorSets:
 #--- end
 
 # UNSUPPORTED: Clang
-# REQUIRES: DirectX
+# UNSUPPORTED: Vulkan, Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: - Name: OutBuf
-# CHECK-NEXT: Format: Int32
-# CHECK-NEXT: Data: [ 1, 0, 0, 0, 5, 6, 0, 0, 9, 10, 11, 0, 13, 14, 15,
-# CHECK-NEXT: 16 ]
+# CHECK-NEXT: Format: Hex32
+# CHECK-NEXT: Data: [ 0x101, 0x0, 0x0, 0x0, 0x505, 0x606, 0x0, 0x0, 0x909,
+# CHECK-NEXT: 0xA0A, 0xB0B, 0x0, 0xD0D, 0xE0E, 0xF0F, 0x1010 ]
 
 # CHECK: - Name: MappedBuf
 # CHECK-NEXT: Format: Int32


### PR DESCRIPTION
Adds test and support for `ByteAddressBuffer` and `RWByteAddressBuffer` (DirectX only).

Fixes llvm/wg-hlsl#201