### PR TITLE
Introduce syntax to specify vulkan bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,22 @@ DescriptorSets:
       DirectXBinding:
         Register: 0 # implies b0 due to Access being Constant
         Space: 0
+      VKBinding:
+        Binding: 0 # [[vk::binding(0, 0)]]
     - Name: In1
       Kind: Buffer
       DirectXBinding:
         Register: 0 # implies t0 due to Access being RO
         Space: 0
+      VKBinding:
+        Binding: 10
   - Resources:
     - Name: In2
       Kind: Buffer
       DirectXBinding:
         Register: 1 # implies t1 due to Access being RO
         Space: 0
+      VKBinding:
+        Binding: 0 # [[vk::binding(0, 1)]]
 ...
 ```

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -56,6 +56,10 @@ struct DirectXBinding {
   uint32_t Space;
 };
 
+struct VulkanBinding {
+  uint32_t Binding;
+};
+
 struct OutputProperties {
   int Height;
   int Width;
@@ -107,6 +111,7 @@ struct Resource {
   ResourceKind Kind;
   std::string Name;
   DirectXBinding DXBinding;
+  std::optional<VulkanBinding> VKBinding;
   Buffer *BufferPtr = nullptr;
 
   bool isRaw() const {
@@ -252,6 +257,10 @@ template <> struct MappingTraits<offloadtest::Resource> {
 
 template <> struct MappingTraits<offloadtest::DirectXBinding> {
   static void mapping(IO &I, offloadtest::DirectXBinding &B);
+};
+
+template <> struct MappingTraits<offloadtest::VulkanBinding> {
+  static void mapping(IO &I, offloadtest::VulkanBinding &B);
 };
 
 template <> struct MappingTraits<offloadtest::OutputProperties> {

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -124,12 +124,18 @@ void MappingTraits<offloadtest::Resource>::mapping(IO &I,
   I.mapRequired("Name", R.Name);
   I.mapRequired("Kind", R.Kind);
   I.mapRequired("DirectXBinding", R.DXBinding);
+  I.mapOptional("VulkanBinding", R.VKBinding);
 }
 
 void MappingTraits<offloadtest::DirectXBinding>::mapping(
     IO &I, offloadtest::DirectXBinding &B) {
   I.mapRequired("Register", B.Register);
   I.mapRequired("Space", B.Space);
+}
+
+void MappingTraits<offloadtest::VulkanBinding>::mapping(
+    IO &I, offloadtest::VulkanBinding &B) {
+  I.mapRequired("Binding", B.Binding);
 }
 
 void MappingTraits<offloadtest::OutputProperties>::mapping(
@@ -144,6 +150,7 @@ void MappingTraits<offloadtest::dx::RootResource>::mapping(
   I.mapRequired("Name", R.Name);
   I.mapRequired("Kind", R.Kind);
   R.DXBinding = {0, 0};
+  R.VKBinding = std::nullopt;
   if (!I.outputting() && !R.isRaw())
     I.setError("Root descriptors must be raw resource types.");
 }

--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -1,14 +1,8 @@
 #--- DescriptorSets.hlsl
 
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx, Space)
-#else
-#define REGISTER(Idx, Space) : register(Idx, Space)
-#endif
-
-[[vk::binding(0)]] RWBuffer<float4> In REGISTER(u0, space0);
-[[vk::binding(1)]] RWBuffer<float4> Out1 REGISTER(u1, space4);
-[[vk::binding(0,1)]] RWBuffer<float4> Out2 REGISTER(u2, space4);
+[[vk::binding(0)]] RWBuffer<float4> In : register(u0, space0);
+[[vk::binding(1)]] RWBuffer<float4> Out1 : register(u1, space4);
+[[vk::binding(0,1)]] RWBuffer<float4> Out2 : register(u2, space4);
 
 [numthreads(1,1,1)]
 void main(uint GI : SV_GroupIndex) {
@@ -41,21 +35,29 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out1
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 4
+      VulkanBinding:
+        Binding: 1
   - Resources:
     - Name: Out2
       Kind: RWBuffer
       DirectXBinding:
         Register: 2
         Space: 4
+      VulkanBinding:
+        Binding: 0
 ...
 #--- end
 
+# Clang doesn't support the `vk::binding` attribute.
 # UNSUPPORTED: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/DescriptorSets.hlsl
 # RUN: %offloader %t/DescriptorSets.yaml %t.o | FileCheck %s

--- a/test/Basic/Mandelbrot.test
+++ b/test/Basic/Mandelbrot.test
@@ -74,6 +74,8 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
 ...
 #--- rules.yaml
 ---

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -27,11 +27,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -28,11 +28,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -1,15 +1,9 @@
 #--- source.hlsl
 
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx)
-#else
-#define REGISTER(Idx) : register(Idx, space0)
-#endif
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
 
-RWBuffer<int> In REGISTER(u0);
-RWBuffer<int> Out REGISTER(u1);
-
-cbuffer CB0 REGISTER(b0) {
+cbuffer CB0 : register(b2) {
   int Constant;
 }
 
@@ -42,16 +36,22 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
     - Name: cbuffer
       Kind: ConstantBuffer
       DirectXBinding:
-        Register: 0
+        Register: 2
         Space: 0
+      VulkanBinding:
+        Binding: 2
 ...
 #--- end
 

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -37,16 +37,22 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Zeros
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
     - Name: NegOnes
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
+      VulkanBinding:
+        Binding: 2
 ...
 #--- end
 

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -1,13 +1,7 @@
 #--- simple.hlsl
 
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx, Space)
-#else
-#define REGISTER(Idx, Space) : register(Idx, Space)
-#endif
-
-RWBuffer<float4> In REGISTER(u0, space0);
-RWBuffer<float4> Out REGISTER(u1, space4);
+RWBuffer<float4> In : register(u0, space0);
+RWBuffer<float4> Out : register(u1, space0);
 
 [numthreads(1,1,1)]
 void main(uint GI : SV_GroupIndex) {
@@ -35,11 +29,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
-        Space: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/Attributes/IfBranchAttr.test
+++ b/test/Feature/Attributes/IfBranchAttr.test
@@ -1,17 +1,10 @@
 #--- source.hlsl
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx)
-#else
-#define REGISTER(Idx) : register(Idx, space0)
-#endif
-
-RWBuffer<int> In REGISTER(u0);
-RWBuffer<int> Out REGISTER(u1);
-
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
-    [flatten] 
+    [flatten]
     if (TID.x) {
         int X = In[TID.x];
         Out[TID.x] = -X;
@@ -39,11 +32,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/Attributes/IfBranchFlatten.test
+++ b/test/Feature/Attributes/IfBranchFlatten.test
@@ -1,17 +1,10 @@
 #--- source.hlsl
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx)
-#else
-#define REGISTER(Idx) : register(Idx, space0)
-#endif
-
-RWBuffer<int> In REGISTER(u0);
-RWBuffer<int> Out REGISTER(u1);
-
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
-    [branch] 
+    [branch]
     if (TID.x) {
         int X = In[TID.x];
         Out[TID.x] = -X;
@@ -39,11 +32,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/Attributes/SwitchBranchAttr.test
+++ b/test/Feature/Attributes/SwitchBranchAttr.test
@@ -1,17 +1,10 @@
 #--- source.hlsl
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx)
-#else
-#define REGISTER(Idx) : register(Idx, space0)
-#endif
-
-RWBuffer<int> In REGISTER(u0);
-RWBuffer<int> Out REGISTER(u1);
-
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
-    [branch] 
+    [branch]
       int X = In[TID.x];
     switch (TID.x % 3) {
       case 0:
@@ -47,11 +40,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/Attributes/SwitchFlattenAttr.test
+++ b/test/Feature/Attributes/SwitchFlattenAttr.test
@@ -1,17 +1,10 @@
 #--- source.hlsl
-#if defined(__spirv__) || defined(__SPIRV__)
-#define REGISTER(Idx)
-#else
-#define REGISTER(Idx) : register(Idx, space0)
-#endif
-
-RWBuffer<int> In REGISTER(u0);
-RWBuffer<int> Out REGISTER(u1);
-
+RWBuffer<int> In : register(u0);
+RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
-    [flatten] 
+    [flatten]
       int X = In[TID.x];
     switch (TID.x % 3) {
       case 0:
@@ -47,11 +40,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -10,7 +10,7 @@ struct Arrays {
   float16_t c2[1];
 };
 
-RWStructuredBuffer<Arrays> Out : register(u0);
+RWStructuredBuffer<Arrays> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -50,7 +50,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -12,7 +12,7 @@ struct Arrays {
   int64_t c3[2];
 };
 
-RWStructuredBuffer<Arrays> Out : register(u0);
+RWStructuredBuffer<Arrays> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -55,7 +55,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -12,7 +12,7 @@ struct Arrays {
   bool c3[2];
 };
 
-RWStructuredBuffer<Arrays> Out : register(u0);
+RWStructuredBuffer<Arrays> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -55,7 +55,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/CBuffer/scalars-16bit.test
+++ b/test/Feature/CBuffer/scalars-16bit.test
@@ -12,7 +12,7 @@ struct Scalars {
   int16_t a3;
 };
 
-RWStructuredBuffer<Scalars> Out : register(u0);
+RWStructuredBuffer<Scalars> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -44,11 +44,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/CBuffer/scalars-64bit.test
+++ b/test/Feature/CBuffer/scalars-64bit.test
@@ -12,7 +12,7 @@ struct Scalars {
   int64_t a3;
 };
 
-RWStructuredBuffer<Scalars> Out : register(u0);
+RWStructuredBuffer<Scalars> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -43,11 +43,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/CBuffer/scalars.test
+++ b/test/Feature/CBuffer/scalars.test
@@ -12,7 +12,7 @@ struct Scalars {
   bool a3;
 };
 
-RWStructuredBuffer<Scalars> Out : register(u0);
+RWStructuredBuffer<Scalars> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -44,11 +44,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -35,7 +35,7 @@ struct S {
   int2 z2ya2;
 };
 
-RWStructuredBuffer<S> Out : register(u0);
+RWStructuredBuffer<S> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -89,7 +89,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -10,7 +10,7 @@ struct Vectors {
   uint16_t3 b2;
 };
 
-RWStructuredBuffer<Vectors> Out : register(u0);
+RWStructuredBuffer<Vectors> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -45,11 +45,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -12,7 +12,7 @@ struct Vectors {
   int64_t3 b3;
 };
 
-RWStructuredBuffer<Vectors> Out : register(u0);
+RWStructuredBuffer<Vectors> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -54,7 +54,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -14,7 +14,7 @@ struct Vectors {
   bool4 b4;
 };
 
-RWStructuredBuffer<Vectors> Out : register(u0);
+RWStructuredBuffer<Vectors> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
@@ -55,7 +55,7 @@ DescriptorSets:
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
 ...
 #--- end

--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -1,17 +1,17 @@
 #--- source.hlsl
 
-RWBuffer<int> A : register(u1);
-RWBuffer<int> B;                 // gets u0
-RWBuffer<int> C: register(u2);   // unused
-RWBuffer<int> D;                 // gets u2
+RWBuffer<int> A; // dx: u0, vk: 0
+StructuredBuffer<int> B; // dx: t0, vk: 1
 
-cbuffer CB { // gets b0
+cbuffer CB { // dx: b0, vk: 2
   int a;
 }
 
+RWStructuredBuffer<int> C; // dx: u1, vk: 3
+
 [numthreads(4,2,1)]
 void main(uint GI : SV_GroupIndex) {
-  D[GI] = 2 * A[GI] + B[GI] + a;
+  C[GI].x = 2 * A[GI] + B[GI].x + a;
 }
 
 //--- pipeline.yaml
@@ -26,10 +26,12 @@ Buffers:
     Data: [ 1, 2, 3, 4, 5, 6, 7, 8]
   - Name: BufB
     Format: Int32
+    Stride: 4
     Data: [ 2, 4, 6, 8, 10, 12, 14, 16]
-  - Name: BufD
+  - Name: BufC
     Format: Int32
-    Data: [ 0, 0, 0, 0, 0, 0, 0, 0]
+    Stride: 4
+    ZeroInitSize: 32
   - Name: CB
     Format: Int32
     Data: [ 100 ]
@@ -38,28 +40,28 @@ DescriptorSets:
     - Name: BufA
       Kind: RWBuffer
       DirectXBinding:
-        Register: 1
-        Space: 0
-      VulkanBinding:
-        Binding: 1
-    - Name: BufB
-      Kind: RWBuffer
-      DirectXBinding:
         Register: 0
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: BufD
-      Kind: RWBuffer
+    - Name: BufB
+      Kind: StructuredBuffer
       DirectXBinding:
-        Register: 2
+        Register: 0
         Space: 0
       VulkanBinding:
-        Binding: 2
+        Binding: 1
     - Name: CB
       Kind: ConstantBuffer
       DirectXBinding:
         Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: BufC
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
         Space: 0
       VulkanBinding:
         Binding: 3
@@ -68,15 +70,12 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang
 
-# DXC's vulkan backend doesn't drop unused bindings, so it isn't possible to
-# specify descriptor sets that are valid for both DirectX and Vulkan there.
-# UNSUPPORTED: DXC-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
 # RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
-# CHECK: Name: BufD
+# CHECK: Name: BufC
 # CHECK-NEXT: Format: Int32
+# CHECK-NEXT: Stride: 4
 # CHECK-NEXT: Data: [ 104, 108, 112, 116, 120, 124, 128, 132 ]

--- a/test/Feature/StructuredBuffer/packed.test
+++ b/test/Feature/StructuredBuffer/packed.test
@@ -33,6 +33,8 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
 ...
 #--- end
 

--- a/test/Feature/StructuredBuffer/simple.test
+++ b/test/Feature/StructuredBuffer/simple.test
@@ -8,7 +8,7 @@ struct S2 {
   int4 i;
 };
 
-StructuredBuffer<S1> In : register(t0);
+StructuredBuffer<S1> In : register(t1);
 RWStructuredBuffer<S2> Out : register(u0);
 
 [numthreads(1,1,1)]
@@ -37,13 +37,17 @@ DescriptorSets:
     - Name: In
       Kind: StructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
 ...
 #--- end
 

--- a/test/Feature/StructuredBuffer/srv.test
+++ b/test/Feature/StructuredBuffer/srv.test
@@ -4,7 +4,7 @@ struct S1 {
 };
 
 StructuredBuffer<S1> In : register(t0);
-RWStructuredBuffer<S1> Out : register(u0);
+RWStructuredBuffer<S1> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main(uint GI : SV_GroupIndex) {
@@ -32,11 +32,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
-        Register: 0
+        Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/Feature/StructuredBuffer/stride.test
+++ b/test/Feature/StructuredBuffer/stride.test
@@ -32,11 +32,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Out
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
 ...
 #--- end
 

--- a/test/WaveOps/GSFlag.test
+++ b/test/WaveOps/GSFlag.test
@@ -38,6 +38,8 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
 ...
 
 #--- end

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -38,21 +38,29 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
     - Name: Infs
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
+      VulkanBinding:
+        Binding: 1
     - Name: NegInfs
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
+      VulkanBinding:
+        Binding: 2
     - Name: Mix
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
+      VulkanBinding:
+        Binding: 3
 ...
 
 #--- end

--- a/test/WaveOps/WaveActiveSum.test
+++ b/test/WaveOps/WaveActiveSum.test
@@ -32,6 +32,8 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
 ...
 #--- end
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -50,7 +50,7 @@ else:
 
 ExtraCompilerArgs = []
 if config.offloadtest_enable_vulkan:
-  ExtraCompilerArgs = ['-spirv']
+  ExtraCompilerArgs = ['-spirv', '-fspv-target-env=vulkan1.3']
 if config.offloadtest_enable_metal:
   ExtraCompilerArgs = ['-metal']
 


### PR DESCRIPTION
This adds a "VKBinding" part for resource descriptors, similar to the already existing DirectXBinding. These are a bit different from DX in that we only specify a binding index - the binding can also have a descriptor set, but that's represented structurally.

There are a few details to be aware of here:

- DXC's behaviour with `register()` annotations is not to differentiate between u/t/b types, so I've adjusted quite a few tests to simply avoid bindings that would have overlap in vulkan.
- Clang does not support the `vk::binding` attribute or the `-vk-*-shift` flag so tricks like the above are the easiest way to make compatible shaders.
- For tests that were buggy on DXC, I've added new tests to cover the shared functionality
- I've defaulted the spirv dxc invocations to specify vulkan1.3 to simplify command lines