### PR TITLE
Fix WSL build

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -9,13 +9,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <wrl/client.h>
+
 #include <cstdint>
 #include <d3d12.h>
 #include <d3dx12.h>
 #include <dxcore.h>
 #include <dxgiformat.h>
 #include <dxguids.h>
-#include <wrl/client.h>
 
 #ifndef _WIN32
 #include <poll.h>


### PR DESCRIPTION
Fixes #70

The include order broke the build on WSL.
`#include <wrl/client.h>` should be included before anything else, and clang-format reordered the includes to put it at the bottom of its neighboring includes.

This PR moves `#include <wrl/client.h>` to the top on its own line so that it gets included first and does not get reordered by clang-format.