### PR TITLE
[NFC] Add Graphics Tools to prerequisites for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This project requires being able to locally build LLVM and leverages LLVM's buil
 pip3 install pyyaml
 ```
 
+On Windows, the [Graphics Tools](https://learn.microsoft.com/en-us/windows/uwp/gaming/use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features) optional feature is additionally required to run the test suite.
+
 # Adding to LLVM Build
 
 Add the following to the CMake options:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project requires being able to locally build LLVM and leverages LLVM's buil
 pip3 install pyyaml
 ```
 
-On Windows, the [Graphics Tools](https://learn.microsoft.com/en-us/windows/uwp/gaming/use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features) optional feature is additionally required to run the test suite.
+On Windows, the [Graphics Tools](https://learn.microsoft.com/en-us/windows/win32/direct3d12/directx-12-programming-environment-set-up#debug-layer) optional feature is additionally required to run the test suite.
 
 # Adding to LLVM Build
 


### PR DESCRIPTION
@spall encountered this issue while setting up the offload test suite on Windows.

The offload test suite uses the DirectX debug layer by default and therefore fails to run correctly when the Graphics Tools optional feature is not installed.

Without Graphics Tools, the error `failed to create D3D12 Debug Interface` will prevent api-query and the offloader from running properly.