### PR TITLE
Add Bool as a Scalar type option

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -38,6 +38,7 @@ enum class DataFormat {
   Int64,
   Float32,
   Float64,
+  Bool,
 };
 
 enum class ResourceKind {
@@ -84,6 +85,7 @@ struct Buffer {
     case DataFormat::UInt32:
     case DataFormat::Int32:
     case DataFormat::Float32:
+    case DataFormat::Bool:
       return 4;
     case DataFormat::Hex64:
     case DataFormat::UInt64:
@@ -291,6 +293,7 @@ template <> struct ScalarEnumerationTraits<offloadtest::DataFormat> {
     ENUM_CASE(Int64);
     ENUM_CASE(Float32);
     ENUM_CASE(Float64);
+    ENUM_CASE(Bool);
 #undef ENUM_CASE
   }
 };

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -113,6 +113,7 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
     DATA_CASE(Int64, int64_t)
     DATA_CASE(Float32, float)
     DATA_CASE(Float64, double)
+    DATA_CASE(Bool, uint32_t) // Because sizeof(bool) is 1 but HLSL represents a bool using 4 bytes.
   }
 
   I.mapOptional("OutputProps", B.OutputProps);


### PR DESCRIPTION
Add Bool to DataFormat Enum, represent it with a uint32_t because HLSL bools are 4 bytes and a C++ bool is 1 byte.
This will be needed for future intrinsic tests.
Closes #73 