### PR TITLE
Add Float16 as a Scalar type option

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -43,6 +43,7 @@ enum class DataFormat {
   Float32,
   Float64,
   Bool,
+  Half,
 };
 
 enum class ResourceKind {
@@ -88,6 +89,7 @@ struct Buffer {
     case DataFormat::Hex16:
     case DataFormat::UInt16:
     case DataFormat::Int16:
+    case DataFormat::Half:
       return 2;
     case DataFormat::Hex32:
     case DataFormat::UInt32:
@@ -343,6 +345,7 @@ template <> struct ScalarEnumerationTraits<offloadtest::DataFormat> {
     ENUM_CASE(Float32);
     ENUM_CASE(Float64);
     ENUM_CASE(Bool);
+    ENUM_CASE(Half);
 #undef ENUM_CASE
   }
 };

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -40,10 +40,10 @@ enum class DataFormat {
   Int16,
   Int32,
   Int64,
+  Float16,
   Float32,
   Float64,
   Bool,
-  Half,
 };
 
 enum class ResourceKind {
@@ -89,7 +89,7 @@ struct Buffer {
     case DataFormat::Hex16:
     case DataFormat::UInt16:
     case DataFormat::Int16:
-    case DataFormat::Half:
+    case DataFormat::Float16:
       return 2;
     case DataFormat::Hex32:
     case DataFormat::UInt32:
@@ -342,10 +342,10 @@ template <> struct ScalarEnumerationTraits<offloadtest::DataFormat> {
     ENUM_CASE(Int16);
     ENUM_CASE(Int32);
     ENUM_CASE(Int64);
+    ENUM_CASE(Float16);
     ENUM_CASE(Float32);
     ENUM_CASE(Float64);
     ENUM_CASE(Bool);
-    ENUM_CASE(Half);
 #undef ENUM_CASE
   }
 };

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -127,10 +127,10 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
     DATA_CASE(Int16, int16_t)
     DATA_CASE(Int32, int32_t)
     DATA_CASE(Int64, int64_t)
+    DATA_CASE(Float16, uint16_t)
     DATA_CASE(Float32, float)
     DATA_CASE(Float64, double)
     DATA_CASE(Bool, uint32_t) // Because sizeof(bool) is 1 but HLSL represents a bool using 4 bytes.
-    DATA_CASE(Half, uint16_t)
   }
 
   I.mapOptional("OutputProps", B.OutputProps);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -130,6 +130,7 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
     DATA_CASE(Float32, float)
     DATA_CASE(Float64, double)
     DATA_CASE(Bool, uint32_t) // Because sizeof(bool) is 1 but HLSL represents a bool using 4 bytes.
+    DATA_CASE(Half, uint16_t)
   }
 
   I.mapOptional("OutputProps", B.OutputProps);


### PR DESCRIPTION
Add Float16 to DataFormat Enum, represented with a uint16_t.
This will be needed for future intrinsic tests.

Closes #79.