### PR TITLE
[Clang-Vulkan] Disable failing tests

### DIFF
--- a/test/Feature/Attributes/IfBranchAttr.test
+++ b/test/Feature/Attributes/IfBranchAttr.test
@@ -48,6 +48,7 @@ DescriptorSets:
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
+# UNSUPPORTED: Clang-Vulkan
 # CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 4, 9, 16, 25, 36, 49, 64 ]

--- a/test/Feature/Attributes/IfBranchFlatten.test
+++ b/test/Feature/Attributes/IfBranchFlatten.test
@@ -48,6 +48,7 @@ DescriptorSets:
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
+# UNSUPPORTED: Clang-Vulkan
 # CHECK: Name: In
 # CHECK: Format: Int32
 # CHECK: Data: [ 1, 4, 9, 16, 25, 36, 49, 64 ]


### PR DESCRIPTION
These tests are failing on clang-vulkan configuration. The Clang-Vulkan config briefly worked, then started immediately failing again and hasn't worked since. For now we've just disabled everything.