### PR TITLE
Update action target to use PR head

### DIFF
--- a/.github/workflows/macos-clang-mtl.yaml
+++ b/.github/workflows/macos-clang-mtl.yaml
@@ -21,4 +21,4 @@ jobs:
       SKU: macOS
       Test-Clang: On
       TestTarget: check-hlsl-clang-mtl
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/macos-dxc-mtl.yaml
+++ b/.github/workflows/macos-dxc-mtl.yaml
@@ -21,4 +21,4 @@ jobs:
       SKU: macOS
       Test-Clang: Off
       TestTarget: check-hlsl-mtl
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -21,5 +21,5 @@ jobs:
       SKU: GPU-Intel
       Test-Clang: On
       TestTarget: check-hlsl-clang-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -21,4 +21,5 @@ jobs:
       SKU: GPU-Intel
       Test-Clang: On
       TestTarget: check-hlsl-clang-vk
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-warp-d3d12.yaml
@@ -21,5 +21,5 @@ jobs:
       SKU: GPU-Intel
       Test-Clang: On
       TestTarget: check-hlsl-clang-warp-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-dxc-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-d3d12.yaml
@@ -22,5 +22,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -22,5 +22,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-vk
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-intel-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-warp-d3d12.yaml
@@ -22,5 +22,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-warp-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-clang-d3d12.yaml
+++ b/.github/workflows/windows-nv-clang-d3d12.yaml
@@ -18,5 +18,5 @@ jobs:
       SKU: GPU-NV
       Test-Clang: On
       TestTarget: check-hlsl-clang-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-clang-vk.yaml
+++ b/.github/workflows/windows-nv-clang-vk.yaml
@@ -18,5 +18,5 @@ jobs:
       SKU: GPU-NV
       Test-Clang: On
       TestTarget: check-hlsl-clang-vk
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nv-dxc-d3d12.yaml
@@ -19,5 +19,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-d3d12
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nv-dxc-vk.yaml
+++ b/.github/workflows/windows-nv-dxc-vk.yaml
@@ -19,5 +19,5 @@ jobs:
       Test-Clang: Off
       BuildType: Debug
       TestTarget: check-hlsl-vk
-      OffloadTest-branch: ${{ github.ref }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl


### PR DESCRIPTION
This uses a fallback option so that it will pull the pull_request head SHA if that value is available, otherwise it will fall back to the github ref value.